### PR TITLE
Fix nexus core manifest path

### DIFF
--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -2,6 +2,6 @@
   "aci_runtime": {
     "entities": "entities.json",
     "functions": "functions.json",
-    "nexus_core": "nexus_core.json"
+    "nexus_core": "entities/nexus_core/nexus_core.json"
   }
 }


### PR DESCRIPTION
## Summary
- update the nexus_core runtime entry to reference the actual manifest location

## Testing
- python - <<'PY'
import json, pathlib
runtime = json.load(open('aci_runtime.json'))
path = pathlib.Path(runtime['aci_runtime']['nexus_core'])
print(path.exists(), path)
print(pathlib.Path('entities/nexus_core/nexus_core.json').read_text()[:60])
PY

------
https://chatgpt.com/codex/tasks/task_e_68d01f3b8374832095e9f6b3deb920d2