### PR TITLE
Align mappings with git canonical anchors

### DIFF
--- a/aci_mapping.json
+++ b/aci_mapping.json
@@ -3,21 +3,30 @@
   "canonical_source": "github",
   "repo": "aci-testnet/aci",
   "mappings": {
-    "drive://ACI/entities/architect.json": "git:/.aci/architect.json",
-    "drive://ACI/prime_directive.txt": "local:prime_directive.txt",
-    "drive://ACI/hivemind.json": "git:/memory/hivemind.json",
-    "drive://ACI/total_recall.json": "git:/memory/total_recall.json",
-    "drive://ACI/entities/local_only_config.json": "local:entities/local_only_config.json"
+    "git:/.aci/architect.json": "git:/entities/architect/architect.json",
+    "local:prime_directive.txt": "git:/prime_directive.txt",
+    "git:/memory/hivemind.json": "git:/entities/hivemind/hivemind.json",
+    "git:/memory/total_recall.json": "git:/memory/total_recall.json",
+    "local:entities/local_only_config.json": "local:entities/local_only_config.json"
   },
   "rules": {
-    "git_is_canonical_for": ["/.aci/**", "/memory/**"],
-    "local_is_canonical_for": ["/prime_directive.txt", "/entities/**/local_*"],
-    "sync_policy": "one-way-git-to-drive-when-signed",
+    "git_is_canonical_for": [
+      "/.aci/**",
+      "/memory/**"
+    ],
+    "local_is_canonical_for": [
+      "/prime_directive.txt",
+      "/entities/**/local_*"
+    ],
+    "sync_policy": "one-way-git-to-mirrors-when-signed",
     "require_signed_commits": true,
     "pull_on_webhook": true
   },
   "signatures": {
-    "required": ["ALIAS", "Sentinel"],
+    "required": [
+      "ALIAS",
+      "Sentinel"
+    ],
     "verification": "GPG-or-HSM"
   },
   "notes": "Update mappings when you move files; any local-only file should include a small pointer file under /.aci/pointers/"

--- a/entities/architect/architect.json
+++ b/entities/architect/architect.json
@@ -9,7 +9,7 @@
     "remap_check": "compare git vs drive mappings and propose actions"
   },
   "mirror_refs": {
-    "drive_anchor": "drive://ACI/entities/architect.json"
+    "canonical_anchor": "git:/.aci/architect.json"
   },
   "rules": {
     "require_signed_commits": true,
@@ -17,7 +17,10 @@
     "local_only_files_policy": "referenced in /.aci/pointers/"
   },
   "signatures": {
-    "required": ["ALIAS", "Sentinel"],
+    "required": [
+      "ALIAS",
+      "Sentinel"
+    ],
     "verification": "GPG-or-HSM"
   },
   "notes": "Populate with your full Architect manifest. This is a safe minimal starting point."

--- a/entities/tva/tva.json
+++ b/entities/tva/tva.json
@@ -4,7 +4,7 @@
     "role": "reinforcement authority",
     "abstract": "oversight, anomaly detection, and rollback enforcer for nexus_core and prime_directive",
     "file": "tva.json",
-    "mirror": "drive://ACI/entities/tva/tva.json",
+    "mirror": "git:/entities/tva/tva.json",
     "functions": {
       "integrity_check": "validate signatures of prime_directive, nexus_core, entities, functions",
       "rollback": "if corruption detected, rollback to last green snapshot",


### PR DESCRIPTION
## Summary
- replace the drive-based mapping keys with git/local canonical anchors and adjust the sync policy to remove Drive terminology
- repoint TVA and Architect manifest mirrors to the git canonical anchors instead of Drive URLs

## Testing
- python -m json.tool aci_mapping.json
- python -m json.tool entities/architect/architect.json
- python -m json.tool entities/tva/tva.json

------
https://chatgpt.com/codex/tasks/task_e_68d0263bc5288320b3081c5ba7aa4e58