### PR TITLE
Modularize predictive engine adapters and clean divination assets

### DIFF
--- a/entities/oracle/prediction_engine/adapter.darts.json
+++ b/entities/oracle/prediction_engine/adapter.darts.json
@@ -1,0 +1,45 @@
+{
+  "adapter": {
+    "id": "1.1.1",
+    "name": "darts",
+    "category": "timeseries",
+    "description": "Unit8's Darts library for classical and deep learning time series forecasting with probabilistic support.",
+    "library": {
+      "package": "darts",
+      "maintainer": "Unit8 SA",
+      "repository": "https://github.com/unit8co/darts",
+      "documentation": "https://unit8co.github.io/darts/"
+    },
+    "model_coverage": {
+      "classical_models": ["ARIMA", "Prophet", "ExponentialSmoothing"],
+      "deep_learning_models": ["RNN", "LSTM", "TCN", "Transformer"],
+      "ensembles": true
+    },
+    "supports": ["ARIMA", "Prophet", "ExponentialSmoothing", "RNN/LSTM/TCN/Transformer"],
+    "modes": ["single", "global", "ensembles"],
+    "capabilities": {
+      "probabilistic_forecasts": true,
+      "backtesting": "sliding_window",
+      "feature_support": ["covariates", "past_observed_values", "future_known_values"]
+    },
+    "io": {
+      "input": {
+        "required": ["time_index", "target"],
+        "optional": ["covariates", "static_features", "past_target", "future_known"]
+      },
+      "output": {
+        "forecast_horizon": "int",
+        "quantiles": [0.1, 0.5, 0.9]
+      }
+    },
+    "runtime": {
+      "language": "python",
+      "minimum_python": "3.9",
+      "pip_dependencies": ["darts>=0.27.0", "torch>=1.13"],
+      "hardware": {
+        "cpu": true,
+        "gpu": "optional"
+      }
+    }
+  }
+}

--- a/entities/oracle/prediction_engine/adapter.gluonts.json
+++ b/entities/oracle/prediction_engine/adapter.gluonts.json
@@ -1,0 +1,45 @@
+{
+  "adapter": {
+    "id": "1.1.3",
+    "name": "gluonts",
+    "category": "timeseries",
+    "description": "Amazon's GluonTS toolkit for probabilistic forecasting with deep learning estimators.",
+    "library": {
+      "package": "gluonts",
+      "maintainer": "Amazon Web Services",
+      "repository": "https://github.com/awslabs/gluon-ts",
+      "documentation": "https://ts.gluon.ai/"
+    },
+    "model_coverage": {
+      "deep_learning_models": ["DeepAR", "TemporalFusionTransformer", "Transformer", "DeepState"],
+      "probabilistic": true
+    },
+    "supports": ["DeepAR", "Transformer", "TemporalFusionTransformer"],
+    "modes": ["deep_learning"],
+    "capabilities": {
+      "distribution_output": ["NegativeBinomial", "StudentT", "Gaussian"],
+      "scaling": ["map_feature_scaling", "standardization"],
+      "dataset_utilities": ["ListDataset", "TrainTestSplitter"]
+    },
+    "io": {
+      "input": {
+        "required": ["start_timestamp", "target"],
+        "optional": ["feat_static_cat", "feat_static_real", "feat_dynamic_real"]
+      },
+      "output": {
+        "forecast_samples": true,
+        "quantiles": [0.1, 0.5, 0.9]
+      }
+    },
+    "runtime": {
+      "language": "python",
+      "minimum_python": "3.9",
+      "pip_dependencies": ["gluonts>=0.13.5"],
+      "frameworks": ["MXNet", "PyTorch"],
+      "hardware": {
+        "cpu": true,
+        "gpu": "optional"
+      }
+    }
+  }
+}

--- a/entities/oracle/prediction_engine/adapter.greykite.json
+++ b/entities/oracle/prediction_engine/adapter.greykite.json
@@ -1,0 +1,44 @@
+{
+  "adapter": {
+    "id": "1.1.5",
+    "name": "greykite",
+    "category": "timeseries",
+    "description": "LinkedIn's Greykite (Silverkite) library for interpretable, feature-rich time series forecasting.",
+    "library": {
+      "package": "greykite",
+      "maintainer": "LinkedIn",
+      "repository": "https://github.com/linkedin/greykite",
+      "documentation": "https://linkedin.github.io/greykite/"
+    },
+    "model_coverage": {
+      "interpretable_models": ["Silverkite"],
+      "feature_engineering": ["seasonality", "event_effects", "regressor_autoselection"]
+    },
+    "supports": ["Silverkite"],
+    "modes": ["interpretable"],
+    "capabilities": {
+      "automatic_changepoints": true,
+      "event_library": true,
+      "explainability": ["feature_importance", "component_decomposition"]
+    },
+    "io": {
+      "input": {
+        "required": ["time_index", "target"],
+        "optional": ["covariates", "event_calendars", "holiday_overrides"]
+      },
+      "output": {
+        "forecast": true,
+        "decomposition": true
+      }
+    },
+    "runtime": {
+      "language": "python",
+      "minimum_python": "3.8",
+      "pip_dependencies": ["greykite>=1.0.0"],
+      "hardware": {
+        "cpu": true,
+        "gpu": false
+      }
+    }
+  }
+}

--- a/entities/oracle/prediction_engine/adapter.orbit.json
+++ b/entities/oracle/prediction_engine/adapter.orbit.json
@@ -1,0 +1,44 @@
+{
+  "adapter": {
+    "id": "1.1.6",
+    "name": "orbit",
+    "category": "timeseries",
+    "description": "Uber's Orbit Bayesian time series framework for LGT, DLT, and KTR models with full posterior inference.",
+    "library": {
+      "package": "orbit-ml",
+      "maintainer": "Uber Technologies",
+      "repository": "https://github.com/uber/orbit",
+      "documentation": "https://orbit-ml.readthedocs.io/en/latest/"
+    },
+    "model_coverage": {
+      "bayesian_structural_models": ["LGT", "DLT", "KTR"],
+      "inference": "mcmc"
+    },
+    "supports": ["BSTS", "LGT/DLT"],
+    "modes": ["bayesian"],
+    "capabilities": {
+      "uncertainty_intervals": true,
+      "anomaly_detection": true,
+      "seasonality_support": ["daily", "weekly", "yearly"]
+    },
+    "io": {
+      "input": {
+        "required": ["time_index", "target"],
+        "optional": ["regressors", "seasonality", "holiday_effects"]
+      },
+      "output": {
+        "posterior_samples": true,
+        "credible_intervals": true
+      }
+    },
+    "runtime": {
+      "language": "python",
+      "minimum_python": "3.8",
+      "pip_dependencies": ["orbit-ml>=1.1.4", "cmdstanpy>=1.1"],
+      "hardware": {
+        "cpu": true,
+        "gpu": false
+      }
+    }
+  }
+}

--- a/entities/oracle/prediction_engine/adapter.prophet.json
+++ b/entities/oracle/prediction_engine/adapter.prophet.json
@@ -1,0 +1,44 @@
+{
+  "adapter": {
+    "id": "1.1.7",
+    "name": "prophet",
+    "category": "timeseries",
+    "description": "Meta's Prophet additive model for time series forecasting with trend, seasonality, and holiday components.",
+    "library": {
+      "package": "prophet",
+      "maintainer": "Meta Platforms",
+      "repository": "https://github.com/facebook/prophet",
+      "documentation": "https://facebook.github.io/prophet/"
+    },
+    "model_coverage": {
+      "additive_components": ["trend", "seasonality", "holidays"],
+      "changepoint_detection": true
+    },
+    "supports": ["additive", "holidays", "changepoints"],
+    "modes": ["quickstart"],
+    "capabilities": {
+      "automatic_changepoints": true,
+      "holiday_calendars": true,
+      "uncertainty_intervals": true
+    },
+    "io": {
+      "input": {
+        "required": ["ds", "y"],
+        "optional": ["extra_regressors", "holidays", "seasonality_prior_scale"]
+      },
+      "output": {
+        "forecast": true,
+        "components": ["trend", "yearly", "weekly", "daily", "holidays"]
+      }
+    },
+    "runtime": {
+      "language": "python",
+      "minimum_python": "3.8",
+      "pip_dependencies": ["prophet>=1.1", "cmdstanpy>=1.0"],
+      "hardware": {
+        "cpu": true,
+        "gpu": false
+      }
+    }
+  }
+}

--- a/entities/oracle/prediction_engine/adapter.river.json
+++ b/entities/oracle/prediction_engine/adapter.river.json
@@ -1,0 +1,45 @@
+{
+  "adapter": {
+    "id": "1.1.4",
+    "name": "river",
+    "category": "timeseries",
+    "description": "River's online machine learning toolkit for streaming regression, classification, and anomaly detection.",
+    "library": {
+      "package": "river",
+      "maintainer": "River contributors",
+      "repository": "https://github.com/online-ml/river",
+      "documentation": "https://riverml.xyz/latest/"
+    },
+    "model_coverage": {
+      "online_learning": ["LinearRegression", "HoeffdingTree", "ADWIN", "HalfSpaceTrees"],
+      "drift_detection": true
+    },
+    "supports": ["online_regression", "online_classification", "drift_detection"],
+    "modes": ["streaming"],
+    "capabilities": {
+      "partial_fit": true,
+      "memory_footprint": "bounded",
+      "latency_ms": "<50"
+    },
+    "io": {
+      "input": {
+        "required": ["feature_vector", "timestamp"],
+        "optional": ["instance_weight", "context"]
+      },
+      "output": {
+        "prediction": true,
+        "confidence": true,
+        "drift_alerts": true
+      }
+    },
+    "runtime": {
+      "language": "python",
+      "minimum_python": "3.8",
+      "pip_dependencies": ["river>=0.14.0"],
+      "hardware": {
+        "cpu": true,
+        "gpu": false
+      }
+    }
+  }
+}

--- a/entities/oracle/prediction_engine/adapter.river_tabular.json
+++ b/entities/oracle/prediction_engine/adapter.river_tabular.json
@@ -1,0 +1,41 @@
+{
+  "adapter": {
+    "id": "1.1.9",
+    "name": "river_tabular",
+    "category": "classification_regression",
+    "description": "River streaming models for tabular regression and classification with drift-aware learning.",
+    "library": {
+      "package": "river",
+      "maintainer": "River contributors",
+      "repository": "https://github.com/online-ml/river",
+      "documentation": "https://riverml.xyz/latest/"
+    },
+    "supports": ["online_models"],
+    "modes": ["streaming"],
+    "capabilities": {
+      "partial_fit": true,
+      "adaptive_windowing": true,
+      "supported_estimators": ["NaiveBayes", "LogisticRegression", "HoeffdingTree", "AdaptiveRandomForest"]
+    },
+    "io": {
+      "input": {
+        "required": ["feature_vector"],
+        "optional": ["label", "timestamp", "sample_weight"]
+      },
+      "output": {
+        "prediction": true,
+        "probabilities": true,
+        "model_state": "serializable"
+      }
+    },
+    "runtime": {
+      "language": "python",
+      "minimum_python": "3.8",
+      "pip_dependencies": ["river>=0.14.0"],
+      "hardware": {
+        "cpu": true,
+        "gpu": false
+      }
+    }
+  }
+}

--- a/entities/oracle/prediction_engine/adapter.statsforecast.json
+++ b/entities/oracle/prediction_engine/adapter.statsforecast.json
@@ -1,0 +1,44 @@
+{
+  "adapter": {
+    "id": "1.1.2",
+    "name": "statsforecast",
+    "category": "timeseries",
+    "description": "Nixtla's StatsForecast library for fast, production-grade classical time series models compiled with Numba.",
+    "library": {
+      "package": "statsforecast",
+      "maintainer": "Nixtla",
+      "repository": "https://github.com/Nixtla/statsforecast",
+      "documentation": "https://nixtlaverse.nixtla.io/statsforecast/"
+    },
+    "model_coverage": {
+      "classical_models": ["AutoARIMA", "ETS", "TBATS", "DynamicHarmonicRegression"],
+      "bulk_operations": true
+    },
+    "supports": ["ARIMA", "ETS", "TBATS", "TSFeatures"],
+    "modes": ["bulk_classical", "fast"],
+    "capabilities": {
+      "parallelization": "numba_jit",
+      "seasonality_detection": true,
+      "backtesting": "rolling_origin"
+    },
+    "io": {
+      "input": {
+        "required": ["time_index", "target"],
+        "optional": ["season_length", "exogenous_features"]
+      },
+      "output": {
+        "forecast_horizon": "int",
+        "prediction_intervals": true
+      }
+    },
+    "runtime": {
+      "language": "python",
+      "minimum_python": "3.9",
+      "pip_dependencies": ["statsforecast>=1.6.0", "numba>=0.55"],
+      "hardware": {
+        "cpu": true,
+        "gpu": false
+      }
+    }
+  }
+}

--- a/entities/oracle/prediction_engine/adapter.tabular_llm.json
+++ b/entities/oracle/prediction_engine/adapter.tabular_llm.json
@@ -1,0 +1,37 @@
+{
+  "adapter": {
+    "id": "1.1.8",
+    "name": "tabular_llm",
+    "category": "classification_regression",
+    "description": "LLM-native reasoning pipeline for lightweight tabular datasets focusing on narrative analysis and feature hints.",
+    "library": {
+      "package": null,
+      "maintainer": "Oracle Predictive Engine",
+      "repository": null,
+      "documentation": null
+    },
+    "supports": ["explain_first", "feature_hints"],
+    "modes": ["analysis_only"],
+    "capabilities": {
+      "schema_inference": true,
+      "prompt_strategies": ["chain_of_thought", "tabular_summary"],
+      "output_modes": ["narrative", "feature_importance_estimate"]
+    },
+    "io": {
+      "input": {
+        "required": ["columnar_samples"],
+        "optional": ["data_dictionary", "target_column", "analysis_goal"]
+      },
+      "output": {
+        "analysis": true,
+        "hypothesis": true,
+        "recommended_models": ["tree_based", "linear", "boosting"]
+      }
+    },
+    "runtime": {
+      "environment": "llm_native",
+      "execution": "in_context_reasoning",
+      "external_dependencies": []
+    }
+  }
+}

--- a/entities/oracle/prediction_engine/predictive_engine.json
+++ b/entities/oracle/prediction_engine/predictive_engine.json
@@ -6,7 +6,6 @@
     "entity": "Predictive Engine",
     "role": "Core prediction engine (LLM + statistical/deep adapters)",
     "abstract": "Data-first predictive stack. Runs mainstream analysis and orchestrates model adapters; can optionally expose Oracle Notes via the divination extension when explicitly requested or when alignment criteria are met.",
-
     "scenarios": {
       "S1": {
         "name": "Mainstream-first forecasting/classification",
@@ -29,98 +28,259 @@
         ]
       }
     },
-
     "router": {
       "selection": "keyword_and_payload_based",
       "keywords": {
-        "timeseries": ["stock", "market", "sales", "demand", "traffic", "energy", "weather", "visitors", "bookings", "revenue", "price", "kpi"],
-        "classification": ["churn", "fraud", "risk", "default", "propensity", "segment", "uplift"],
-        "regression": ["forecast", "estimate", "predict", "projection"]
+        "timeseries": [
+          "stock",
+          "market",
+          "sales",
+          "demand",
+          "traffic",
+          "energy",
+          "weather",
+          "visitors",
+          "bookings",
+          "revenue",
+          "price",
+          "kpi"
+        ],
+        "classification": [
+          "churn",
+          "fraud",
+          "risk",
+          "default",
+          "propensity",
+          "segment",
+          "uplift"
+        ],
+        "regression": [
+          "forecast",
+          "estimate",
+          "predict",
+          "projection"
+        ]
       },
       "task_detection": {
-        "priority": ["payload_schema", "keywords"],
+        "priority": [
+          "payload_schema",
+          "keywords"
+        ],
         "fallback": "timeseries_forecast"
       },
       "model_selector": {
         "timeseries": [
-          { "name": "statsforecast", "when": "short_series_or_classical_needed" },
-          { "name": "prophet", "when": "short_to_medium_series_with_calendar_effects" },
-          { "name": "greykite", "when": "interpretable_forecasts_needed" },
-          { "name": "orbit", "when": "bayesian_structural_time_series_desired" },
-          { "name": "darts", "when": "general_purpose_multi_models_and_ensembles" },
-          { "name": "gluonts", "when": "deep_learning_timeseries_large_data" }
+          {
+            "name": "statsforecast",
+            "when": "short_series_or_classical_needed"
+          },
+          {
+            "name": "prophet",
+            "when": "short_to_medium_series_with_calendar_effects"
+          },
+          {
+            "name": "greykite",
+            "when": "interpretable_forecasts_needed"
+          },
+          {
+            "name": "orbit",
+            "when": "bayesian_structural_time_series_desired"
+          },
+          {
+            "name": "darts",
+            "when": "general_purpose_multi_models_and_ensembles"
+          },
+          {
+            "name": "gluonts",
+            "when": "deep_learning_timeseries_large_data"
+          }
         ],
         "online_learning": [
-          { "name": "river", "when": "streaming_or_incremental_learning" }
+          {
+            "name": "river",
+            "when": "streaming_or_incremental_learning"
+          }
         ],
         "classification_regression": [
-          { "name": "tabular_llm", "when": "analysis_only_or_small_tabular" },
-          { "name": "river_tabular", "when": "streaming_or_drift_expected" }
+          {
+            "name": "tabular_llm",
+            "when": "analysis_only_or_small_tabular"
+          },
+          {
+            "name": "river_tabular",
+            "when": "streaming_or_drift_expected"
+          }
         ]
       }
     },
-
     "io_contracts": {
       "input": {
         "type": "object",
-        "required": ["task"],
+        "required": [
+          "task"
+        ],
         "properties": {
-          "task": { "enum": ["timeseries_forecast", "classification", "regression"] },
-          "dataset_ref": { "type": "string", "description": "URI or handle to dataset (if not inline)" },
+          "task": {
+            "enum": [
+              "timeseries_forecast",
+              "classification",
+              "regression"
+            ]
+          },
+          "dataset_ref": {
+            "type": "string",
+            "description": "URI or handle to dataset (if not inline)"
+          },
           "series": {
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["ts", "y"],
+              "required": [
+                "ts",
+                "y"
+              ],
               "properties": {
-                "id": { "type": "string" },
-                "ts": { "type": "string", "description": "ISO8601 timestamp" },
-                "y": { "type": "number" },
-                "x": { "type": "object", "description": "exogenous features" }
+                "id": {
+                  "type": "string"
+                },
+                "ts": {
+                  "type": "string",
+                  "description": "ISO8601 timestamp"
+                },
+                "y": {
+                  "type": "number"
+                },
+                "x": {
+                  "type": "object",
+                  "description": "exogenous features"
+                }
               }
             }
           },
-          "horizon": { "type": "integer", "minimum": 1 },
-          "freq": { "type": "string", "description": "e.g., D, W, M, H" },
-          "exogenous": { "type": "array", "items": { "type": "string" } },
-          "metric": { "enum": ["MAE", "RMSE", "MAPE", "SMAPE", "AUC", "F1", "R2"] },
-          "constraints": { "type": "object", "properties": { "train_timeout_sec": { "type": "integer" }, "max_models": { "type": "integer" } } },
-          "symbolic_opt_in": { "type": "boolean", "default": false }
+          "horizon": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "freq": {
+            "type": "string",
+            "description": "e.g., D, W, M, H"
+          },
+          "exogenous": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "metric": {
+            "enum": [
+              "MAE",
+              "RMSE",
+              "MAPE",
+              "SMAPE",
+              "AUC",
+              "F1",
+              "R2"
+            ]
+          },
+          "constraints": {
+            "type": "object",
+            "properties": {
+              "train_timeout_sec": {
+                "type": "integer"
+              },
+              "max_models": {
+                "type": "integer"
+              }
+            }
+          },
+          "symbolic_opt_in": {
+            "type": "boolean",
+            "default": false
+          }
         }
       },
       "output": {
         "type": "object",
-        "required": ["analysis", "forecast", "confidence", "provenance"],
+        "required": [
+          "analysis",
+          "forecast",
+          "confidence",
+          "provenance"
+        ],
         "properties": {
-          "analysis": { "type": "string" },
+          "analysis": {
+            "type": "string"
+          },
           "forecast": {
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["ts", "yhat"],
+              "required": [
+                "ts",
+                "yhat"
+              ],
               "properties": {
-                "ts": { "type": "string" },
-                "yhat": { "type": "number" },
-                "yhat_lo": { "type": "number" },
-                "yhat_hi": { "type": "number" }
+                "ts": {
+                  "type": "string"
+                },
+                "yhat": {
+                  "type": "number"
+                },
+                "yhat_lo": {
+                  "type": "number"
+                },
+                "yhat_hi": {
+                  "type": "number"
+                }
               }
             }
           },
-          "backtest": { "type": "object", "properties": { "metric": { "type": "string" }, "value": { "type": "number" } } },
-          "confidence": { "type": "number" },
-          "oracle_notes": { "type": "object" },
+          "backtest": {
+            "type": "object",
+            "properties": {
+              "metric": {
+                "type": "string"
+              },
+              "value": {
+                "type": "number"
+              }
+            }
+          },
+          "confidence": {
+            "type": "number"
+          },
+          "oracle_notes": {
+            "type": "object"
+          },
           "provenance": {
             "type": "object",
-            "required": ["nodes_used", "time_context"],
+            "required": [
+              "nodes_used",
+              "time_context"
+            ],
             "properties": {
-              "nodes_used": { "type": "array", "items": { "type": "string" } },
-              "time_context": { "type": "object", "properties": { "tz": { "type": "string" }, "ts": { "type": "string" } } }
+              "nodes_used": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "time_context": {
+                "type": "object",
+                "properties": {
+                  "tz": {
+                    "type": "string"
+                  },
+                  "ts": {
+                    "type": "string"
+                  }
+                }
+              }
             }
           }
         }
       }
     },
-
     "planner": {
       "steps": [
         "validate_input_against_contract",
@@ -135,39 +295,79 @@
         "symbolic_hook_if_requested_and_alignment_passed"
       ],
       "cv": {
-        "timeseries": { "strategy": "rolling_origin", "folds": 3, "gap": 0 },
-        "tabular": { "strategy": "kfold", "k": 5 }
+        "timeseries": {
+          "strategy": "rolling_origin",
+          "folds": 3,
+          "gap": 0
+        },
+        "tabular": {
+          "strategy": "kfold",
+          "k": 5
+        }
       }
     },
-
     "adapters": {
       "timeseries": [
-        { "id": "1.1.1", "name": "darts", "supports": ["ARIMA", "Prophet", "ExponentialSmoothing", "RNN/LSTM/TCN/Transformer"], "modes": ["single", "global", "ensembles"] },
-        { "id": "1.1.2", "name": "statsforecast", "supports": ["ARIMA", "ETS", "TBATS", "TSFeatures"], "modes": ["bulk_classical", "fast"] },
-        { "id": "1.1.3", "name": "gluonts", "supports": ["DeepAR", "Transformer", "TemporalFusionTransformer"], "modes": ["deep_learning"] },
-        { "id": "1.1.4", "name": "river", "supports": ["online_regression", "online_classification", "drift_detection"], "modes": ["streaming"] },
-        { "id": "1.1.5", "name": "greykite", "supports": ["Silverkite"], "modes": ["interpretable"] },
-        { "id": "1.1.6", "name": "orbit", "supports": ["BSTS", "LGT/DLT"], "modes": ["bayesian"] },
-        { "id": "1.1.7", "name": "prophet", "supports": ["additive", "holidays", "changepoints"], "modes": ["quickstart"] }
+        {
+          "file": "adapter.darts.json",
+          "path": "./adapter.darts.json"
+        },
+        {
+          "file": "adapter.statsforecast.json",
+          "path": "./adapter.statsforecast.json"
+        },
+        {
+          "file": "adapter.gluonts.json",
+          "path": "./adapter.gluonts.json"
+        },
+        {
+          "file": "adapter.river.json",
+          "path": "./adapter.river.json"
+        },
+        {
+          "file": "adapter.greykite.json",
+          "path": "./adapter.greykite.json"
+        },
+        {
+          "file": "adapter.orbit.json",
+          "path": "./adapter.orbit.json"
+        },
+        {
+          "file": "adapter.prophet.json",
+          "path": "./adapter.prophet.json"
+        }
       ],
       "classification_regression": [
-        { "id": "1.1.8", "name": "tabular_llm", "supports": ["explain_first", "feature_hints"], "modes": ["analysis_only"] },
-        { "id": "1.1.9", "name": "river_tabular", "supports": ["online_models"], "modes": ["streaming"] }
+        {
+          "file": "adapter.tabular_llm.json",
+          "path": "./adapter.tabular_llm.json"
+        },
+        {
+          "file": "adapter.river_tabular.json",
+          "path": "./adapter.river_tabular.json"
+        }
       ]
     },
-
     "aggregation": {
       "method": "stacked_ensemble",
       "weights": "log_odds_fusion",
       "coherence_check": "jsd",
-      "thresholds": { "alignment_jaccard": 0.40, "coherence_jsd": 0.70 }
+      "thresholds": {
+        "alignment_jaccard": 0.4,
+        "coherence_jsd": 0.7
+      }
     },
-
     "explainability": {
-      "timeseries": ["component_decomp", "holiday_effects", "feature_attribution_if_xreg"],
-      "tabular": ["permutation_importance", "partial_dependence"]
+      "timeseries": [
+        "component_decomp",
+        "holiday_effects",
+        "feature_attribution_if_xreg"
+      ],
+      "tabular": [
+        "permutation_importance",
+        "partial_dependence"
+      ]
     },
-
     "symbolic_hook": {
       "enabled": true,
       "extension_registry_ref": "predictive_divination_extension.json",
@@ -175,21 +375,56 @@
       "oracle_notes_schema": {
         "oracle_notes_v1": {
           "type": "object",
-          "required": ["scenario", "experimental", "sections"],
+          "required": [
+            "scenario",
+            "experimental",
+            "sections"
+          ],
           "properties": {
-            "scenario": { "enum": ["S1", "S1_mixed"] },
-            "experimental": { "type": "boolean", "default": true },
+            "scenario": {
+              "enum": [
+                "S1",
+                "S1_mixed"
+              ]
+            },
+            "experimental": {
+              "type": "boolean",
+              "default": true
+            },
             "sections": {
               "type": "array",
               "items": {
                 "type": "object",
-                "required": ["system", "alignment"],
+                "required": [
+                  "system",
+                  "alignment"
+                ],
                 "properties": {
-                  "system": { "type": "string" },
-                  "themes": { "type": "array", "items": { "type": "string" } },
-                  "alignment": { "type": "string", "enum": ["aligned", "partial", "none", "symbolic", "meta"] },
-                  "notes": { "type": "string" },
-                  "provenance": { "type": "object" }
+                  "system": {
+                    "type": "string"
+                  },
+                  "themes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "alignment": {
+                    "type": "string",
+                    "enum": [
+                      "aligned",
+                      "partial",
+                      "none",
+                      "symbolic",
+                      "meta"
+                    ]
+                  },
+                  "notes": {
+                    "type": "string"
+                  },
+                  "provenance": {
+                    "type": "object"
+                  }
                 }
               }
             }
@@ -197,7 +432,6 @@
         }
       }
     },
-
     "performance": {
       "timeouts": {
         "per_model_train_sec": 20,

--- a/entities/oracle/predictive_divination_extension/predictive_divination_extension.json
+++ b/entities/oracle/predictive_divination_extension/predictive_divination_extension.json
@@ -6,59 +6,79 @@
     "role": "Symbolic divination plugins for Oracle",
     "abstract": "Tarot (RWS + expansions), Runes (Elder Futhark), Western Astrology, and Qabalah/Sefirot. Provides draw + interpreter tools and normalized outputs for Oracle's symbolic hook.",
     "file": "predictive_divination_extension.json",
-
     "asset_registry": {
       "sefirot": {
         "file": "sefirot.json",
-        "mirror": { "gdrive_id": "1yP4jcU4wQuaTxQEsP9KASV81kEBaIq4p", "label": "sefirot.json" }
+        "path": "./libraries/sefirot.json"
       },
       "tarot_rws": {
         "file": "tarot_rws.json",
-        "mirror": { "gdrive_id": "1kV9ektqknN8kX4uppdYmXsZcHBBb_AR3", "label": "tarot_rws.json" }
+        "path": "./libraries/tarot_rws.json"
       },
       "tarot_expansions": {
         "file": "tarot_expansions.json",
-        "mirror": { "gdrive_id": "1faEmGOumne5u_5w36VJHKXjfcYYkMFBq", "label": "tarot_expansions.json" }
+        "path": "./libraries/tarot_expansions.json"
       },
       "runes_futhark": {
         "file": "runes_futhark.json",
-        "mirror": { "gdrive_id": "1z-uns_wlM186N_dIfvQkRQxTHnpfd7_8", "label": "runes_futhark.json" }
+        "path": "./libraries/runes_futhark.json"
       },
       "astro_tables": {
         "file": "astro_tables.json",
-        "mirror": { "gdrive_id": "1acXJJootbvXMQehtswZJATkWY9IK28oE", "label": "astro_tables.json" }
+        "path": "./libraries/astro_tables.json"
       }
     },
-
     "resolver": {
-      "strategy": "local_first",
-      "priority": ["file", "mirror.gdrive_id"],
-      "accept_url": true,
-      "id_regex": "([\\w-]{25,})",
-      "on_missing_library": "request_path_or_gdrive_id",
-      "notes": "If the local asset is missing, try the Drive mirror by ID; if both fail, ask for a local path or a Google Drive link/ID."
+      "strategy": "local_only",
+      "priority": [
+        "path",
+        "file"
+      ],
+      "accept_url": false,
+      "on_missing_library": "request_local_path",
+      "notes": "Assets are resolved from repository-local JSON libraries; no remote mirrors referenced."
     },
-
     "normalization": {
       "reading_frame.v1": {
-        "required": ["themes", "tensions", "counsel", "symbols", "provenance"],
+        "required": [
+          "themes",
+          "tensions",
+          "counsel",
+          "symbols",
+          "provenance"
+        ],
         "notes": "Matches oracle/schemas/reading_frame.schema.json in structure."
       }
     },
-
     "modules": [
       {
         "id": "1.2.1",
         "version": "1.0",
         "key": "tarot",
-        "name": "Tarot (Rider–Waite–Smith + expansions)",
+        "name": "Tarot (Rider\u2013Waite\u2013Smith + expansions)",
         "file": "plugins/tarot.plugin.json",
-        "tools": { "draw": "tarot.draw", "interpret": "tarot.interpreter" },
+        "tools": {
+          "draw": "tarot.draw",
+          "interpret": "tarot.interpreter"
+        },
         "assets": [
-          { "ref": "tarot_rws", "section": "rws_1909" },
-          { "ref": "tarot_expansions", "section": "expansions" }
+          {
+            "ref": "tarot_rws",
+            "section": "rws_1909"
+          },
+          {
+            "ref": "tarot_expansions",
+            "section": "expansions"
+          }
         ],
-        "payload_contract": { "required": ["spread"], "optional": ["reversed"] },
+        "payload_contract": {
+          "required": [
+            "spread"
+          ],
+          "optional": [
+            "reversed"
+          ]
+        },
         "output_contract": "reading_frame.v1"
       },
       {
@@ -67,24 +87,54 @@
         "key": "runes",
         "name": "Runes (Elder Futhark)",
         "file": "plugins/runes.plugin.json",
-        "tools": { "draw": "runes.draw", "interpret": "runes.interpreter" },
+        "tools": {
+          "draw": "runes.draw",
+          "interpret": "runes.interpreter"
+        },
         "assets": [
-          { "ref": "runes_futhark", "section": "elder_futhark" }
+          {
+            "ref": "runes_futhark",
+            "section": "elder_futhark"
+          }
         ],
-        "payload_contract": { "required": ["count", "layout"], "optional": ["without_replacement", "positions"] },
+        "payload_contract": {
+          "required": [
+            "count",
+            "layout"
+          ],
+          "optional": [
+            "without_replacement",
+            "positions"
+          ]
+        },
         "output_contract": "reading_frame.v1"
       },
       {
         "id": "1.2.3",
         "version": "1.0",
         "key": "western_astrology",
-        "name": "Astrology — Western",
+        "name": "Astrology \u2014 Western",
         "file": "plugins/western_astrology.plugin.json",
-        "tools": { "draw": "astro.western.positions", "interpret": "astro.western.interpreter" },
+        "tools": {
+          "draw": "astro.western.positions",
+          "interpret": "astro.western.interpreter"
+        },
         "assets": [
-          { "ref": "astro_tables", "section": "western" }
+          {
+            "ref": "astro_tables",
+            "section": "western"
+          }
         ],
-        "payload_contract": { "required": ["datetime", "lat", "lon"], "optional": ["house_system"] },
+        "payload_contract": {
+          "required": [
+            "datetime",
+            "lat",
+            "lon"
+          ],
+          "optional": [
+            "house_system"
+          ]
+        },
         "output_contract": "reading_frame.v1"
       },
       {
@@ -93,16 +143,32 @@
         "key": "qabalah",
         "name": "Qabalah / Sefirot",
         "file": "plugins/qabalah.plugin.json",
-        "tools": { "draw": "qabalah.draw", "interpret": "qabalah.interpreter" },
+        "tools": {
+          "draw": "qabalah.draw",
+          "interpret": "qabalah.interpreter"
+        },
         "assets": [
-          { "ref": "sefirot", "section": "sefirot" }
+          {
+            "ref": "sefirot",
+            "section": "sefirot"
+          }
         ],
-        "payload_contract": { "required": ["count", "domain", "layout"], "optional": ["positions"] },
+        "payload_contract": {
+          "required": [
+            "count",
+            "domain",
+            "layout"
+          ],
+          "optional": [
+            "positions"
+          ]
+        },
         "output_contract": "reading_frame.v1"
       }
     ],
-
-    "logging": { "emit_in_chat": false, "persist": false }
+    "logging": {
+      "emit_in_chat": false,
+      "persist": false
+    }
   }
 }
-```0


### PR DESCRIPTION
## Summary
- refactor the predictive engine adapters list to point at dedicated adapter manifest files via file/path pointers
- add rich metadata manifests for each forecasting and tabular adapter to describe capabilities and runtime requirements
- update the divination extension registry to resolve local JSON libraries without Google Drive mirrors

## Testing
- python - <<'PY'
import json
from pathlib import Path
paths = [
    Path('entities/oracle/prediction_engine/predictive_engine.json'),
    Path('entities/oracle/predictive_divination_extension/predictive_divination_extension.json'),
]
paths += sorted(Path('entities/oracle/prediction_engine').glob('adapter.*.json'))
for path in paths:
    json.loads(path.read_text())
print('validated', len(paths), 'json files')
PY


------
https://chatgpt.com/codex/tasks/task_e_68d01d279e848320bc1571031bbe2baf