### PR TITLE
Restore ACI repo module include and add repo pipelines

### DIFF
--- a/entities/aci_repo/aci_repo.json
+++ b/entities/aci_repo/aci_repo.json
@@ -1,0 +1,147 @@
+{
+  "version": "BASELINE-2025-09-21",
+  "entity": "ACI Repo",
+  "pipelines": {
+    "aci.repo.search": {
+      "description": "Search the ACI package repository for modules matching the provided query.",
+      "steps": [
+        {
+          "call": "aci-repo.search",
+          "map": {
+            "query": "$args.query",
+            "filters": "$args.filters",
+            "limit": "$args.limit"
+          }
+        },
+        {
+          "call": "sentinel.audit",
+          "map": {
+            "layer": "aci_repo",
+            "action": "search",
+            "query": "$args.query"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
+      ]
+    },
+    "aci.repo.search.improve": {
+      "description": "Search the repository and emit focused improvement recommendations for the requested entity.",
+      "steps": [
+        {
+          "call": "aci-repo.search",
+          "map": {
+            "query": "$args.entity",
+            "filters": [
+              "category:entity"
+            ],
+            "limit": 25
+          }
+        },
+        {
+          "call": "aci-repo.suggest_improvements",
+          "map": {
+            "entity": "$args.entity",
+            "results": "$prev"
+          }
+        },
+        {
+          "call": "sentinel.audit",
+          "map": {
+            "layer": "aci_repo",
+            "action": "search.improve",
+            "entity": "$args.entity"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
+      ]
+    },
+    "aci.repo.install": {
+      "description": "Install or activate an ACI package into the current workspace.",
+      "steps": [
+        {
+          "call": "aci-repo.install",
+          "map": {
+            "package": "$args.package",
+            "version": "$args.version",
+            "options": "$args.options"
+          }
+        },
+        {
+          "call": "sentinel.audit",
+          "map": {
+            "layer": "aci_repo",
+            "action": "install",
+            "package": "$args.package",
+            "version": "$args.version"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
+      ]
+    },
+    "aci.repo.remove": {
+      "description": "Remove a previously installed ACI package while preserving rollback data.",
+      "steps": [
+        {
+          "call": "aci-repo.remove",
+          "map": {
+            "package": "$args.package",
+            "options": "$args.options"
+          }
+        },
+        {
+          "call": "sentinel.audit",
+          "map": {
+            "layer": "aci_repo",
+            "action": "remove",
+            "package": "$args.package"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
+      ]
+    },
+    "aci.repo.update": {
+      "description": "Update installed ACI packages, optionally targeting a specific module.",
+      "steps": [
+        {
+          "call": "aci-repo.update",
+          "map": {
+            "package": "$args.package",
+            "mode": "$args.mode"
+          }
+        },
+        {
+          "call": "sentinel.audit",
+          "map": {
+            "layer": "aci_repo",
+            "action": "update",
+            "package": "$args.package",
+            "mode": "$args.mode"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
+      ]
+    },
+    "aci.repo.help": {
+      "description": "Display usage guidance for the ACI repository subsystem.",
+      "steps": [
+        {
+          "call": "aci-repo.help_index",
+          "map": {}
+        },
+        {
+          "call": "_format.json"
+        }
+      ]
+    }
+  }
+}

--- a/functions.json
+++ b/functions.json
@@ -349,7 +349,7 @@
         {
           "call": "include",
           "map": {
-            "file": "aci_repo.json"
+            "file": "entities/aci_repo/aci_repo.json"
           }
         },
         {


### PR DESCRIPTION
## Summary
- add a dedicated `entities/aci_repo/aci_repo.json` manifest that defines the repo pipelines referenced by the CLI commands
- point both the root pipeline and the module handoff back at `aci_repo.json` so the new manifest is loaded correctly

## Testing
- `python - <<'PY'
import json, pathlib
root = pathlib.Path('entities/aci_repo')
api = json.loads(root.joinpath('api_repo.json').read_text())
repo = json.loads(root.joinpath('aci_repo.json').read_text())
api_pipelines = set(api.get('pipelines', {}).keys())
repo_pipelines = set(repo.get('pipelines', {}).keys())
cli_commands = api.get('cli', {}).get('commands', [])
cli_pipelines = {cmd['pipeline'] for cmd in cli_commands}
missing = sorted(p for p in cli_pipelines if p not in api_pipelines and p not in repo_pipelines)
if missing:
    print('CLI pipelines missing definitions:', missing)
else:
    print('All CLI pipelines have definitions in API or repo manifests.')
referenced = api_pipelines | cli_pipelines
orphan_repo = sorted(p for p in repo_pipelines if p not in referenced)
if orphan_repo:
    print('Orphaned repo pipelines (defined but not referenced):', orphan_repo)
else:
    print('No orphaned repo pipelines detected.')
PY`
- `python - <<'PY'
import json, pathlib
root_manifest = pathlib.Path('functions.json')
root_data = json.loads(root_manifest.read_text())
include_step = root_data['pipelines']['aci.repo']['steps'][0]
include_file = include_step['map']['file']
include_path = root_manifest.parent / include_file
print('Root include path:', include_path)
module_manifest = include_path
module_data = json.loads(module_manifest.read_text())
print('Module pipelines available:', sorted(module_data.get('pipelines', {}).keys()))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68d00edce0dc8320b51d7f494f1ab3f8