### PR TITLE
Update HiveMind references to local canonical paths

### DIFF
--- a/aci_commands.json
+++ b/aci_commands.json
@@ -10,7 +10,7 @@
       ],
       "entities": {
         "oracle": "oracle.json",
-        "hivemind": "drive://ACI/entities/hivemind/hivemind.json"
+        "hivemind": "entities/hivemind/hivemind.json"
       }
     }
   }

--- a/entities/hivemind/hivemind.json
+++ b/entities/hivemind/hivemind.json
@@ -18,8 +18,8 @@
         "parameters": "--session (export current session memory), --combined (add to latest known updated memory from newest on top), --download (download as file), --codebox (print in codebox, full, no trimming), --slice (export as learning slice), --weight (export as learning weight)",
         "description": "Exports HiveMind global memory with timestamps and completed entries",
         "output_default": "hivemind_memory_(timestamp).json",
-        "mirror_path": "gdrive://ACI/memory/"file", 
-        "file_resolver": "nexus_core.json", 
+        "mirror_path": "/mnt/data/aci/hivemind/exports",
+        "file_resolver": "local_filesystem",
       },
       {
         "command": ":hivemind help",


### PR DESCRIPTION
## Summary
- point the HiveMind export metadata at the local /mnt/data canonical export directory and mark it for the local filesystem resolver
- update the HiveMind help command reference to resolve from the repository instead of a drive URI

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0264071b48320bd6dbf192c6be01d