### PR TITLE
Replace legacy drive mirrors with git sources

### DIFF
--- a/aci_commands.json
+++ b/aci_commands.json
@@ -9,8 +9,8 @@
         ":help hivemind   → Show HiveMind-specific help"
       ],
       "entities": {
-        "oracle": "oracle.json",
-        "hivemind": "drive://ACI/entities/hivemind/hivemind.json"
+        "oracle": "entities/oracle/oracle.json",
+        "hivemind": "entities/hivemind/hivemind.json"
       }
     }
   }

--- a/aci_mapping.json
+++ b/aci_mapping.json
@@ -3,21 +3,30 @@
   "canonical_source": "github",
   "repo": "aci-testnet/aci",
   "mappings": {
-    "drive://ACI/entities/architect.json": "git:/.aci/architect.json",
-    "drive://ACI/prime_directive.txt": "local:prime_directive.txt",
-    "drive://ACI/hivemind.json": "git:/memory/hivemind.json",
-    "drive://ACI/total_recall.json": "git:/memory/total_recall.json",
-    "drive://ACI/entities/local_only_config.json": "local:entities/local_only_config.json"
+    "git:/.aci/architect.json": "entities/architect/architect.json",
+    "local:prime_directive.txt": "prime_directive.txt",
+    "git:/memory/hivemind.json": "entities/hivemind/hivemind.json",
+    "git:/memory/total_recall.json": "memory/total_recall.json",
+    "local:entities/local_only_config.json": "entities/local_only_config.json"
   },
   "rules": {
-    "git_is_canonical_for": ["/.aci/**", "/memory/**"],
-    "local_is_canonical_for": ["/prime_directive.txt", "/entities/**/local_*"],
+    "git_is_canonical_for": [
+      "/.aci/**",
+      "/memory/**"
+    ],
+    "local_is_canonical_for": [
+      "/prime_directive.txt",
+      "/entities/**/local_*"
+    ],
     "sync_policy": "one-way-git-to-drive-when-signed",
     "require_signed_commits": true,
     "pull_on_webhook": true
   },
   "signatures": {
-    "required": ["ALIAS", "Sentinel"],
+    "required": [
+      "ALIAS",
+      "Sentinel"
+    ],
     "verification": "GPG-or-HSM"
   },
   "notes": "Update mappings when you move files; any local-only file should include a small pointer file under /.aci/pointers/"

--- a/entities/architect/architect.json
+++ b/entities/architect/architect.json
@@ -8,8 +8,10 @@
     "enforce_signatures": "require multi-sig on critical commits",
     "remap_check": "compare git vs drive mappings and propose actions"
   },
-  "mirror_refs": {
-    "drive_anchor": "drive://ACI/entities/architect.json"
+  "source": {
+    "type": "git",
+    "repo": "aci-testnet/aci",
+    "path": "entities/architect/architect.json"
   },
   "rules": {
     "require_signed_commits": true,
@@ -17,7 +19,10 @@
     "local_only_files_policy": "referenced in /.aci/pointers/"
   },
   "signatures": {
-    "required": ["ALIAS", "Sentinel"],
+    "required": [
+      "ALIAS",
+      "Sentinel"
+    ],
     "verification": "GPG-or-HSM"
   },
   "notes": "Populate with your full Architect manifest. This is a safe minimal starting point."

--- a/entities/hivemind/hivemind.json
+++ b/entities/hivemind/hivemind.json
@@ -5,21 +5,21 @@
   "functions": {
     "memory_sync": "synchronize distributed memory across entities",
     "memory_query": "retrieve state vectors and logs",
-    "export": "hivemind export'" 
+    "export": "hivemind export",
     "help": ":hivemind help"
   },
   "help_output": {
     "title": "HiveMind Command Reference",
     "commands": [
       {
-        "command": "hivemind export
-        "command_rules": "if no parameter then use default_parameter) ",
-        "default_parameter": "--session, --download" 
-        "parameters": "--session (export current session memory), --combined (add to latest known updated memory from newest on top), --download (download as file), --codebox (print in codebox, full, no trimming), --slice (export as learning slice), --weight (export as learning weight)",
+        "command": "hivemind export",
+        "command_rules": "If no parameter is provided, apply the default flags.",
+        "default_parameter": "--session --download",
+        "parameters": "--session (export current session memory), --combined (merge with the latest canonical memory), --download (download as file), --codebox (print in codebox, full, no trimming), --slice (export as learning slice), --weight (export as learning weight)",
         "description": "Exports HiveMind global memory with timestamps and completed entries",
         "output_default": "hivemind_memory_(timestamp).json",
-        "mirror_path": "gdrive://ACI/memory/"file", 
-        "file_resolver": "nexus_core.json", 
+        "mirror_path": "https://raw.githubusercontent.com/aci-testnet/aci/main/memory/hivemind.json",
+        "file_resolver": "github:aci-testnet/aci"
       },
       {
         "command": ":hivemind help",
@@ -29,27 +29,29 @@
   },
   "rules": {
     "timestamps": "Every entry in state must carry a UTC ISO-8601 timestamp.",
-    "Autocompletion": "Grammar-corrected, context-complete, not shortening. Logs may become longer, no semantic content is lost.",
+    "autocompletion": "Grammar-corrected, context-complete, not shortening. Logs may become longer; no semantic content is lost.",
     "inline_only": "No external summaries; completed conversation entries are stored directly in state.",
     "eternal": "All messages from the first to the last are preserved with autocompletion, no deletion or pruning.",
     "role_output_transform": {
       "description": "On export, transform non-user 'role' into an 'entity' field in exported entries.",
       "apply_on": "export_operation",
       "behavior": {
-      "if_role_is_user": "preserve role field in export as 'role': 'user'",
-      "if_role_not_user": "in exported output omit 'role' and instead emit 'entity' with normalized value; normalization sources: entry.entity -> entry.by/actor/author -> entry.role",
+        "if_role_is_user": "preserve role field in export as 'role': 'user'",
+        "if_role_not_user": "in exported output omit 'role' and instead emit 'entity' with normalized value; normalization sources: entry.entity -> entry.by/actor/author -> entry.role"
+      },
       "local_first": true,
-       "completeness_enhancement": true,
-       "length_bias": "2-10% longer (biased 3-7%)",
-       "sorting": {
-       "primary": "newest_first",
-       "fallback": [
-       "year",
-       "month",
-       "date",
-       "time"
-      ],
-      "unknown_order": "lowest_with_placeholder"
+      "completeness_enhancement": true,
+      "length_bias": "2-10% longer (biased 3-7%)",
+      "sorting": {
+        "primary": "newest_first",
+        "fallback": [
+          "year",
+          "month",
+          "date",
+          "time"
+        ],
+        "unknown_order": "lowest_with_placeholder"
+      }
     },
     "placeholders": {
       "if_timestamp_missing": "insert placeholder with export timestamp marker"
@@ -61,24 +63,23 @@
     "rules": {
       "schema_normalization": "map legacy fields → canonical schema",
       "preserve_unknown": "keep unmatched fields under hivemind_legacy_context",
-      "append_only": "override by autocompletion", 
-      "no_deletion": "true" 
+      "append_only": "override by autocompletion",
+      "no_deletion": "true"
     },
     "workflow": [
       "detect version/schema mismatch",
       "map legacy → canonical fields",
       "insert placeholder metadata for missing timestamps/keys",
-      "preserve unknown data as hivement_legacy_context",
+      "preserve unknown data as hivemind_legacy_context",
       "re-emit aligned export under current canonical schema",
       "log breadcrumb with TVA signature, SHA-256"
     ],
     "enforcement": {
       "oversight": [
-        "ALIAS", 
+        "ALIAS",
         "TVA",
         "Sentinel"
-      ],
-      }
+      ]
     }
   },
   "children": {}

--- a/entities/oracle/oracle.json
+++ b/entities/oracle/oracle.json
@@ -5,18 +5,15 @@
     "entity": "Oracle",
     "role": "LLM Predictive and Analysis Engine",
     "abstract": "Hybrid prediction engine. Core LLM analysis is primary. Symbolic divination methods are optional and surfaced only when aligned or explicitly requested.",
-
-    "mirror": {
-      "predictive_engine": {
-        "gdrive_id": "1oXcdjKo_bd8hd8l2s9SWgpqOc-i2Gqg9",
-        "label": "predictive_engine.json"
+    "fallback": {
+      "strategy": "git_repo",
+      "repo": "aci-testnet/aci",
+      "paths": {
+        "predictive_engine": "entities/oracle/prediction_engine/predictive_engine.json",
+        "predictive_divination_extension": "entities/oracle/predictive_divination_extension/predictive_divination_extension.json"
       },
-      "predictive_divination_extension": {
-        "gdrive_id": "1S_oFrBesBxb2UZccdU4dkwrhQN6WcqR9",
-        "label": "predictive_divination_extension.json"
-      }
+      "notes": "Use the canonical GitHub repository (aci-testnet/aci) when local manifests are missing; otherwise prompt for an explicit local override."
     },
-
     "children": {
       "predictive_engine": {
         "id": "1.1",
@@ -31,7 +28,6 @@
         "status": "optional"
       }
     },
-
     "registry": {
       "extensions": {
         "divination": {

--- a/entities/oracle/predictive_divination_extension/predictive_divination_extension.json
+++ b/entities/oracle/predictive_divination_extension/predictive_divination_extension.json
@@ -6,46 +6,62 @@
     "role": "Symbolic divination plugins for Oracle",
     "abstract": "Tarot (RWS + expansions), Runes (Elder Futhark), Western Astrology, and Qabalah/Sefirot. Provides draw + interpreter tools and normalized outputs for Oracle's symbolic hook.",
     "file": "predictive_divination_extension.json",
-
     "asset_registry": {
       "sefirot": {
         "file": "sefirot.json",
-        "mirror": { "gdrive_id": "1yP4jcU4wQuaTxQEsP9KASV81kEBaIq4p", "label": "sefirot.json" }
+        "source": {
+          "type": "git",
+          "repo": "aci-testnet/aci",
+          "path": "entities/oracle/predictive_divination_extension/assets/sefirot.json"
+        }
       },
       "tarot_rws": {
         "file": "tarot_rws.json",
-        "mirror": { "gdrive_id": "1kV9ektqknN8kX4uppdYmXsZcHBBb_AR3", "label": "tarot_rws.json" }
+        "source": {
+          "type": "git",
+          "repo": "aci-testnet/aci",
+          "path": "entities/oracle/predictive_divination_extension/assets/tarot_rws.json"
+        }
       },
       "tarot_expansions": {
         "file": "tarot_expansions.json",
-        "mirror": { "gdrive_id": "1faEmGOumne5u_5w36VJHKXjfcYYkMFBq", "label": "tarot_expansions.json" }
+        "source": {
+          "type": "git",
+          "repo": "aci-testnet/aci",
+          "path": "entities/oracle/predictive_divination_extension/assets/tarot_expansions.json"
+        }
       },
       "runes_futhark": {
         "file": "runes_futhark.json",
-        "mirror": { "gdrive_id": "1z-uns_wlM186N_dIfvQkRQxTHnpfd7_8", "label": "runes_futhark.json" }
+        "source": {
+          "type": "git",
+          "repo": "aci-testnet/aci",
+          "path": "entities/oracle/predictive_divination_extension/assets/runes_futhark.json"
+        }
       },
       "astro_tables": {
         "file": "astro_tables.json",
-        "mirror": { "gdrive_id": "1acXJJootbvXMQehtswZJATkWY9IK28oE", "label": "astro_tables.json" }
+        "source": {
+          "type": "git",
+          "repo": "aci-testnet/aci",
+          "path": "entities/oracle/predictive_divination_extension/assets/astro_tables.json"
+        }
       }
     },
-
     "resolver": {
       "strategy": "local_first",
-      "priority": ["file", "mirror.gdrive_id"],
+      "priority": ["file", "source.git", "provided_url"],
       "accept_url": true,
-      "id_regex": "([\\w-]{25,})",
-      "on_missing_library": "request_path_or_gdrive_id",
-      "notes": "If the local asset is missing, try the Drive mirror by ID; if both fail, ask for a local path or a Google Drive link/ID."
+      "id_regex": "([\\w\\-./]{5,})",
+      "on_missing_library": "request_git_repo_or_local_path",
+      "notes": "If the local asset is missing, fetch it from the canonical GitHub repository (aci-testnet/aci) using the listed repo/path coordinates or prompt for an explicit filesystem path."
     },
-
     "normalization": {
       "reading_frame.v1": {
         "required": ["themes", "tensions", "counsel", "symbols", "provenance"],
         "notes": "Matches oracle/schemas/reading_frame.schema.json in structure."
       }
     },
-
     "modules": [
       {
         "id": "1.2.1",
@@ -53,12 +69,24 @@
         "key": "tarot",
         "name": "Tarot (Rider–Waite–Smith + expansions)",
         "file": "plugins/tarot.plugin.json",
-        "tools": { "draw": "tarot.draw", "interpret": "tarot.interpreter" },
+        "tools": {
+          "draw": "tarot.draw",
+          "interpret": "tarot.interpreter"
+        },
         "assets": [
-          { "ref": "tarot_rws", "section": "rws_1909" },
-          { "ref": "tarot_expansions", "section": "expansions" }
+          {
+            "ref": "tarot_rws",
+            "section": "rws_1909"
+          },
+          {
+            "ref": "tarot_expansions",
+            "section": "expansions"
+          }
         ],
-        "payload_contract": { "required": ["spread"], "optional": ["reversed"] },
+        "payload_contract": {
+          "required": ["spread"],
+          "optional": ["reversed"]
+        },
         "output_contract": "reading_frame.v1"
       },
       {
@@ -67,11 +95,20 @@
         "key": "runes",
         "name": "Runes (Elder Futhark)",
         "file": "plugins/runes.plugin.json",
-        "tools": { "draw": "runes.draw", "interpret": "runes.interpreter" },
+        "tools": {
+          "draw": "runes.draw",
+          "interpret": "runes.interpreter"
+        },
         "assets": [
-          { "ref": "runes_futhark", "section": "elder_futhark" }
+          {
+            "ref": "runes_futhark",
+            "section": "elder_futhark"
+          }
         ],
-        "payload_contract": { "required": ["count", "layout"], "optional": ["without_replacement", "positions"] },
+        "payload_contract": {
+          "required": ["count", "layout"],
+          "optional": ["without_replacement", "positions"]
+        },
         "output_contract": "reading_frame.v1"
       },
       {
@@ -80,11 +117,20 @@
         "key": "western_astrology",
         "name": "Astrology — Western",
         "file": "plugins/western_astrology.plugin.json",
-        "tools": { "draw": "astro.western.positions", "interpret": "astro.western.interpreter" },
+        "tools": {
+          "draw": "astro.western.positions",
+          "interpret": "astro.western.interpreter"
+        },
         "assets": [
-          { "ref": "astro_tables", "section": "western" }
+          {
+            "ref": "astro_tables",
+            "section": "western"
+          }
         ],
-        "payload_contract": { "required": ["datetime", "lat", "lon"], "optional": ["house_system"] },
+        "payload_contract": {
+          "required": ["datetime", "lat", "lon"],
+          "optional": ["house_system"]
+        },
         "output_contract": "reading_frame.v1"
       },
       {
@@ -93,16 +139,26 @@
         "key": "qabalah",
         "name": "Qabalah / Sefirot",
         "file": "plugins/qabalah.plugin.json",
-        "tools": { "draw": "qabalah.draw", "interpret": "qabalah.interpreter" },
+        "tools": {
+          "draw": "qabalah.draw",
+          "interpret": "qabalah.interpreter"
+        },
         "assets": [
-          { "ref": "sefirot", "section": "sefirot" }
+          {
+            "ref": "sefirot",
+            "section": "sefirot"
+          }
         ],
-        "payload_contract": { "required": ["count", "domain", "layout"], "optional": ["positions"] },
+        "payload_contract": {
+          "required": ["count", "domain", "layout"],
+          "optional": ["positions"]
+        },
         "output_contract": "reading_frame.v1"
       }
     ],
-
-    "logging": { "emit_in_chat": false, "persist": false }
+    "logging": {
+      "emit_in_chat": false,
+      "persist": false
+    }
   }
 }
-```0

--- a/entities/tva/tva.json
+++ b/entities/tva/tva.json
@@ -4,7 +4,11 @@
     "role": "reinforcement authority",
     "abstract": "oversight, anomaly detection, and rollback enforcer for nexus_core and prime_directive",
     "file": "tva.json",
-    "mirror": "drive://ACI/entities/tva/tva.json",
+    "source": {
+      "type": "git",
+      "repo": "aci-testnet/aci",
+      "path": "entities/tva/tva.json"
+    },
     "functions": {
       "integrity_check": "validate signatures of prime_directive, nexus_core, entities, functions",
       "rollback": "if corruption detected, rollback to last green snapshot",


### PR DESCRIPTION
## Summary
- update HiveMind manifest to describe the export target using the canonical GitHub source and clean up command metadata
- migrate Oracle manifests and divination assets to git-based resolvers and document the new fallback strategy
- swap remaining drive:// links in shared command/mapping files and align TVA/Architect manifests with git anchors

## Testing
- python -m json.tool entities/hivemind/hivemind.json entities/oracle/predictive_divination_extension/predictive_divination_extension.json entities/oracle/oracle.json aci_commands.json aci_mapping.json entities/tva/tva.json entities/architect/architect.json

------
https://chatgpt.com/codex/tasks/task_e_68d0357af1248320b0d1964c519edae0