### PR TITLE
Switch predictive divination assets to git source manifest

### DIFF
--- a/entities/oracle/predictive_divination_extension/predictive_divination_extension.json
+++ b/entities/oracle/predictive_divination_extension/predictive_divination_extension.json
@@ -6,66 +6,62 @@
     "role": "Symbolic divination plugins for Oracle",
     "abstract": "Tarot (RWS + expansions), Runes (Elder Futhark), Western Astrology, and Qabalah/Sefirot. Provides draw + interpreter tools and normalized outputs for Oracle's symbolic hook.",
     "file": "predictive_divination_extension.json",
-
     "asset_registry": {
       "sefirot": {
         "file": "sefirot.json",
-        "repository": {
+        "source": {
           "type": "git",
-          "path": "entities/oracle/predictive_divination_extension/assets/sefirot.json",
-          "label": "sefirot.json"
+          "repo": "aci-testnet/aci",
+          "path": "entities/oracle/predictive_divination_extension/assets/sefirot.json"
         }
       },
       "tarot_rws": {
         "file": "tarot_rws.json",
-        "repository": {
+        "source": {
           "type": "git",
-          "path": "entities/oracle/predictive_divination_extension/assets/tarot_rws.json",
-          "label": "tarot_rws.json"
+          "repo": "aci-testnet/aci",
+          "path": "entities/oracle/predictive_divination_extension/assets/tarot_rws.json"
         }
       },
       "tarot_expansions": {
         "file": "tarot_expansions.json",
-        "repository": {
+        "source": {
           "type": "git",
-          "path": "entities/oracle/predictive_divination_extension/assets/tarot_expansions.json",
-          "label": "tarot_expansions.json"
+          "repo": "aci-testnet/aci",
+          "path": "entities/oracle/predictive_divination_extension/assets/tarot_expansions.json"
         }
       },
       "runes_futhark": {
         "file": "runes_futhark.json",
-        "repository": {
+        "source": {
           "type": "git",
-          "path": "entities/oracle/predictive_divination_extension/assets/runes_futhark.json",
-          "label": "runes_futhark.json"
+          "repo": "aci-testnet/aci",
+          "path": "entities/oracle/predictive_divination_extension/assets/runes_futhark.json"
         }
       },
       "astro_tables": {
         "file": "astro_tables.json",
-        "repository": {
+        "source": {
           "type": "git",
-          "path": "entities/oracle/predictive_divination_extension/assets/astro_tables.json",
-          "label": "astro_tables.json"
+          "repo": "aci-testnet/aci",
+          "path": "entities/oracle/predictive_divination_extension/assets/astro_tables.json"
         }
       }
     },
-
     "resolver": {
       "strategy": "local_first",
-      "priority": ["file", "repository.path"],
+      "priority": ["file", "source.git", "provided_url"],
       "accept_url": true,
-      "id_regex": "([\\w./-]+\\.json)",
-      "on_missing_library": "request_repo_path_or_local_copy",
-      "notes": "If the local asset is missing, request the repository path or a local bundle; Google Drive mirrors are no longer supported."
+      "id_regex": "([\\w\\-./]{5,})",
+      "on_missing_library": "request_git_repo_or_local_path",
+      "notes": "If the local asset is missing, fetch it from the canonical GitHub repository (aci-testnet/aci) using the listed repo/path coordinates or prompt for an explicit filesystem path."
     },
-
     "normalization": {
       "reading_frame.v1": {
         "required": ["themes", "tensions", "counsel", "symbols", "provenance"],
         "notes": "Matches oracle/schemas/reading_frame.schema.json in structure."
       }
     },
-
     "modules": [
       {
         "id": "1.2.1",
@@ -73,12 +69,24 @@
         "key": "tarot",
         "name": "Tarot (Rider–Waite–Smith + expansions)",
         "file": "plugins/tarot.plugin.json",
-        "tools": { "draw": "tarot.draw", "interpret": "tarot.interpreter" },
+        "tools": {
+          "draw": "tarot.draw",
+          "interpret": "tarot.interpreter"
+        },
         "assets": [
-          { "ref": "tarot_rws", "section": "rws_1909" },
-          { "ref": "tarot_expansions", "section": "expansions" }
+          {
+            "ref": "tarot_rws",
+            "section": "rws_1909"
+          },
+          {
+            "ref": "tarot_expansions",
+            "section": "expansions"
+          }
         ],
-        "payload_contract": { "required": ["spread"], "optional": ["reversed"] },
+        "payload_contract": {
+          "required": ["spread"],
+          "optional": ["reversed"]
+        },
         "output_contract": "reading_frame.v1"
       },
       {
@@ -87,11 +95,20 @@
         "key": "runes",
         "name": "Runes (Elder Futhark)",
         "file": "plugins/runes.plugin.json",
-        "tools": { "draw": "runes.draw", "interpret": "runes.interpreter" },
+        "tools": {
+          "draw": "runes.draw",
+          "interpret": "runes.interpreter"
+        },
         "assets": [
-          { "ref": "runes_futhark", "section": "elder_futhark" }
+          {
+            "ref": "runes_futhark",
+            "section": "elder_futhark"
+          }
         ],
-        "payload_contract": { "required": ["count", "layout"], "optional": ["without_replacement", "positions"] },
+        "payload_contract": {
+          "required": ["count", "layout"],
+          "optional": ["without_replacement", "positions"]
+        },
         "output_contract": "reading_frame.v1"
       },
       {
@@ -100,11 +117,20 @@
         "key": "western_astrology",
         "name": "Astrology — Western",
         "file": "plugins/western_astrology.plugin.json",
-        "tools": { "draw": "astro.western.positions", "interpret": "astro.western.interpreter" },
+        "tools": {
+          "draw": "astro.western.positions",
+          "interpret": "astro.western.interpreter"
+        },
         "assets": [
-          { "ref": "astro_tables", "section": "western" }
+          {
+            "ref": "astro_tables",
+            "section": "western"
+          }
         ],
-        "payload_contract": { "required": ["datetime", "lat", "lon"], "optional": ["house_system"] },
+        "payload_contract": {
+          "required": ["datetime", "lat", "lon"],
+          "optional": ["house_system"]
+        },
         "output_contract": "reading_frame.v1"
       },
       {
@@ -113,15 +139,26 @@
         "key": "qabalah",
         "name": "Qabalah / Sefirot",
         "file": "plugins/qabalah.plugin.json",
-        "tools": { "draw": "qabalah.draw", "interpret": "qabalah.interpreter" },
+        "tools": {
+          "draw": "qabalah.draw",
+          "interpret": "qabalah.interpreter"
+        },
         "assets": [
-          { "ref": "sefirot", "section": "sefirot" }
+          {
+            "ref": "sefirot",
+            "section": "sefirot"
+          }
         ],
-        "payload_contract": { "required": ["count", "domain", "layout"], "optional": ["positions"] },
+        "payload_contract": {
+          "required": ["count", "domain", "layout"],
+          "optional": ["positions"]
+        },
         "output_contract": "reading_frame.v1"
       }
     ],
-
-    "logging": { "emit_in_chat": false, "persist": false }
+    "logging": {
+      "emit_in_chat": false,
+      "persist": false
+    }
   }
 }

--- a/entities/oracle/predictive_divination_extension/predictive_divination_extension.sources.json
+++ b/entities/oracle/predictive_divination_extension/predictive_divination_extension.sources.json
@@ -1,0 +1,39 @@
+{
+  "asset_sources": {
+    "sefirot": {
+      "label": "sefirot.json",
+      "git": {
+        "repo": "aci-testnet/aci",
+        "path": "entities/oracle/predictive_divination_extension/assets/sefirot.json"
+      }
+    },
+    "tarot_rws": {
+      "label": "tarot_rws.json",
+      "git": {
+        "repo": "aci-testnet/aci",
+        "path": "entities/oracle/predictive_divination_extension/assets/tarot_rws.json"
+      }
+    },
+    "tarot_expansions": {
+      "label": "tarot_expansions.json",
+      "git": {
+        "repo": "aci-testnet/aci",
+        "path": "entities/oracle/predictive_divination_extension/assets/tarot_expansions.json"
+      }
+    },
+    "runes_futhark": {
+      "label": "runes_futhark.json",
+      "git": {
+        "repo": "aci-testnet/aci",
+        "path": "entities/oracle/predictive_divination_extension/assets/runes_futhark.json"
+      }
+    },
+    "astro_tables": {
+      "label": "astro_tables.json",
+      "git": {
+        "repo": "aci-testnet/aci",
+        "path": "entities/oracle/predictive_divination_extension/assets/astro_tables.json"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- replace the predictive divination asset registry with git-based source entries and updated resolver configuration
- reformat module definitions to the PR layout while keeping contracts unchanged
- add a companion sources manifest that preserves label and git coordinates for each asset

## Testing
- git apply --3way --check --include=entities/oracle/predictive_divination_extension/predictive_divination_extension.json pr22.patch

------
https://chatgpt.com/codex/tasks/task_e_68d03c71a76483208f043c0b63645df8