### PR TITLE
Align Oracle fallback handling with git repo strategy

### DIFF
--- a/entities/oracle/oracle.json
+++ b/entities/oracle/oracle.json
@@ -6,14 +6,18 @@
     "role": "LLM Predictive and Analysis Engine",
     "abstract": "Hybrid prediction engine. Core LLM analysis is primary. Symbolic divination methods are optional and surfaced only when aligned or explicitly requested.",
 
-    "mirror": {
-      "predictive_engine": {
-        "repo_path": "entities/oracle/prediction_engine/predictive_engine.json",
-        "label": "predictive_engine.json"
-      },
-      "predictive_divination_extension": {
-        "repo_path": "entities/oracle/predictive_divination_extension/predictive_divination_extension.json",
-        "label": "predictive_divination_extension.json"
+    "fallback": {
+      "strategy": "git_repo",
+      "repository": "aci-testnet/aci",
+      "paths": {
+        "predictive_engine": {
+          "path": "entities/oracle/prediction_engine/predictive_engine.json",
+          "label": "predictive_engine.json"
+        },
+        "predictive_divination_extension": {
+          "path": "entities/oracle/predictive_divination_extension/predictive_divination_extension.json",
+          "label": "predictive_divination_extension.json"
+        }
       }
     },
 


### PR DESCRIPTION
## Summary
- replace the Oracle mirror section with a git_repo fallback definition that points to the predictive engine and divination extension assets
- keep the child and registry metadata unchanged while ensuring no Google Drive IDs remain

## Testing
- python3 -m json.tool entities/oracle/oracle.json
- rg '<<<<<<<' -n

------
https://chatgpt.com/codex/tasks/task_e_68d03c9164708320a0d6fd15ae47ec8d