### PR TITLE
Sanitize HiveMind help pointer

### DIFF
--- a/.aci/pointers/architect.json
+++ b/.aci/pointers/architect.json
@@ -1,0 +1,7 @@
+{
+  "id": "architect",
+  "canonical": "git:/.aci/architect.json",
+  "local_path": "entities/architect/architect.json",
+  "legacy_mirror": "drive://ACI/entities/architect.json",
+  "notes": "Legacy drive mirror reference relocated from aci_mapping.json."
+}

--- a/.aci/pointers/hivemind.json
+++ b/.aci/pointers/hivemind.json
@@ -1,0 +1,7 @@
+{
+  "id": "hivemind",
+  "canonical": "git:/memory/hivemind.json",
+  "local_path": "entities/hivemind/hivemind.json",
+  "legacy_mirror": "drive://ACI/entities/hivemind/hivemind.json",
+  "notes": "Legacy drive mirror reference relocated from aci_commands.json and aci_mapping.json."
+}

--- a/.aci/pointers/local_only_config.json
+++ b/.aci/pointers/local_only_config.json
@@ -1,0 +1,7 @@
+{
+  "id": "local_only_config",
+  "canonical": "local:entities/local_only_config.json",
+  "local_path": "entities/local_only_config.json",
+  "legacy_mirror": "drive://ACI/entities/local_only_config.json",
+  "notes": "Legacy drive mirror reference relocated from aci_mapping.json."
+}

--- a/.aci/pointers/prime_directive.json
+++ b/.aci/pointers/prime_directive.json
@@ -1,0 +1,7 @@
+{
+  "id": "prime_directive",
+  "canonical": "local:prime_directive.txt",
+  "local_path": "prime_directive.txt",
+  "legacy_mirror": "drive://ACI/prime_directive.txt",
+  "notes": "Legacy drive mirror reference relocated from aci_mapping.json."
+}

--- a/.aci/pointers/total_recall.json
+++ b/.aci/pointers/total_recall.json
@@ -1,0 +1,7 @@
+{
+  "id": "total_recall",
+  "canonical": "git:/memory/total_recall.json",
+  "local_path": "memory/total_recall.json",
+  "legacy_mirror": "drive://ACI/total_recall.json",
+  "notes": "Legacy drive mirror reference relocated from aci_mapping.json."
+}

--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 <!--
 **aci-testnet/aci-testnet** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
 --! >
+
+## Mirror pointer housekeeping
+
+- The `:help` command entries now reference repository-relative files only.
+- Legacy mirror locations once embedded in top-level configuration files have been relocated to pointer metadata under `.aci/pointers/` for TVA compliance.
+- See `.aci/pointers/hivemind.json` for the HiveMind mirror mapping formerly referenced directly by `aci_commands.json`.

--- a/aci_commands.json
+++ b/aci_commands.json
@@ -10,7 +10,7 @@
       ],
       "entities": {
         "oracle": "oracle.json",
-        "hivemind": "drive://ACI/entities/hivemind/hivemind.json"
+        "hivemind": "entities/hivemind/hivemind.json"
       }
     }
   }

--- a/aci_mapping.json
+++ b/aci_mapping.json
@@ -9,12 +9,12 @@
   "version": "1.20250921.00",
   "canonical_source": "github",
   "repo": "aci-testnet/aci",
-  "mappings": {
-    "drive://ACI/entities/architect.json": "git:/.aci/architect.json",
-    "drive://ACI/prime_directive.txt": "local:prime_directive.txt",
-    "drive://ACI/hivemind.json": "git:/memory/hivemind.json",
-    "drive://ACI/total_recall.json": "git:/memory/total_recall.json",
-    "drive://ACI/entities/local_only_config.json": "local:entities/local_only_config.json"
+  "pointer_index": {
+    "architect": ".aci/pointers/architect.json",
+    "prime_directive": ".aci/pointers/prime_directive.json",
+    "hivemind": ".aci/pointers/hivemind.json",
+    "total_recall": ".aci/pointers/total_recall.json",
+    "local_only_config": ".aci/pointers/local_only_config.json"
   },
   "rules": {
     "git_is_canonical_for": [


### PR DESCRIPTION
## Summary
- point the `:help` HiveMind entry at the repository-relative configuration file
- replace the top-level drive mirror map with a pointer index and add metadata files under `.aci/pointers/`
- document the relocation of legacy mirror URIs in the README

## Testing
- python -m json.tool aci_commands.json
- python -m json.tool aci_mapping.json
- for file in .aci/pointers/*.json; do python -m json.tool "$file"; done

------
https://chatgpt.com/codex/tasks/task_e_68d0aa8d80a48320afa350a93b4b98c3