### PR TITLE
Restore predictive divination assets

### DIFF
--- a/entities/oracle/predictive_divination_extension/assets/astro_tables.json
+++ b/entities/oracle/predictive_divination_extension/assets/astro_tables.json
@@ -1,0 +1,916 @@
+{
+  "western": {
+    "metadata": {
+      "epoch": "Tropical",
+      "timezone_assumption": "UTC unless birth location supplies zone",
+      "sources": [
+        "Swiss Ephemeris public domain tables (summary)",
+        "Alan Leo modern astrological keywords (public domain)"
+      ]
+    },
+    "signs": [
+      {
+        "name": "Aries",
+        "symbol": "♈",
+        "element": "Fire",
+        "modality": "Cardinal",
+        "ruler": "Mars",
+        "date_range": {
+          "start": "03-20",
+          "end": "04-19"
+        },
+        "polarity": "positive",
+        "opposite": "Libra",
+        "keywords": [
+          "initiative",
+          "courage",
+          "pioneering"
+        ],
+        "decans": [
+          {
+            "decan": 1,
+            "ruler": "Mars"
+          },
+          {
+            "decan": 2,
+            "ruler": "Sun"
+          },
+          {
+            "decan": 3,
+            "ruler": "Venus"
+          }
+        ]
+      },
+      {
+        "name": "Taurus",
+        "symbol": "♉",
+        "element": "Earth",
+        "modality": "Fixed",
+        "ruler": "Venus",
+        "date_range": {
+          "start": "04-19",
+          "end": "05-20"
+        },
+        "polarity": "negative",
+        "opposite": "Scorpio",
+        "keywords": [
+          "stability",
+          "sensuality",
+          "persistence"
+        ],
+        "decans": [
+          {
+            "decan": 1,
+            "ruler": "Mercury"
+          },
+          {
+            "decan": 2,
+            "ruler": "Moon"
+          },
+          {
+            "decan": 3,
+            "ruler": "Saturn"
+          }
+        ]
+      },
+      {
+        "name": "Gemini",
+        "symbol": "♊",
+        "element": "Air",
+        "modality": "Mutable",
+        "ruler": "Mercury",
+        "date_range": {
+          "start": "05-20",
+          "end": "06-20"
+        },
+        "polarity": "positive",
+        "opposite": "Sagittarius",
+        "keywords": [
+          "communication",
+          "adaptability",
+          "curiosity"
+        ],
+        "decans": [
+          {
+            "decan": 1,
+            "ruler": "Jupiter"
+          },
+          {
+            "decan": 2,
+            "ruler": "Mars"
+          },
+          {
+            "decan": 3,
+            "ruler": "Sun"
+          }
+        ]
+      },
+      {
+        "name": "Cancer",
+        "symbol": "♋",
+        "element": "Water",
+        "modality": "Cardinal",
+        "ruler": "Moon",
+        "date_range": {
+          "start": "06-20",
+          "end": "07-22"
+        },
+        "polarity": "negative",
+        "opposite": "Capricorn",
+        "keywords": [
+          "nurturing",
+          "protection",
+          "memory"
+        ],
+        "decans": [
+          {
+            "decan": 1,
+            "ruler": "Venus"
+          },
+          {
+            "decan": 2,
+            "ruler": "Mercury"
+          },
+          {
+            "decan": 3,
+            "ruler": "Moon"
+          }
+        ]
+      },
+      {
+        "name": "Leo",
+        "symbol": "♌",
+        "element": "Fire",
+        "modality": "Fixed",
+        "ruler": "Sun",
+        "date_range": {
+          "start": "07-22",
+          "end": "08-22"
+        },
+        "polarity": "positive",
+        "opposite": "Aquarius",
+        "keywords": [
+          "leadership",
+          "creative expression",
+          "confidence"
+        ],
+        "decans": [
+          {
+            "decan": 1,
+            "ruler": "Saturn"
+          },
+          {
+            "decan": 2,
+            "ruler": "Jupiter"
+          },
+          {
+            "decan": 3,
+            "ruler": "Mars"
+          }
+        ]
+      },
+      {
+        "name": "Virgo",
+        "symbol": "♍",
+        "element": "Earth",
+        "modality": "Mutable",
+        "ruler": "Mercury",
+        "date_range": {
+          "start": "08-22",
+          "end": "09-22"
+        },
+        "polarity": "negative",
+        "opposite": "Pisces",
+        "keywords": [
+          "analysis",
+          "service",
+          "craft"
+        ],
+        "decans": [
+          {
+            "decan": 1,
+            "ruler": "Sun"
+          },
+          {
+            "decan": 2,
+            "ruler": "Venus"
+          },
+          {
+            "decan": 3,
+            "ruler": "Mercury"
+          }
+        ]
+      },
+      {
+        "name": "Libra",
+        "symbol": "♎",
+        "element": "Air",
+        "modality": "Cardinal",
+        "ruler": "Venus",
+        "date_range": {
+          "start": "09-22",
+          "end": "10-22"
+        },
+        "polarity": "positive",
+        "opposite": "Aries",
+        "keywords": [
+          "balance",
+          "diplomacy",
+          "aesthetics"
+        ],
+        "decans": [
+          {
+            "decan": 1,
+            "ruler": "Moon"
+          },
+          {
+            "decan": 2,
+            "ruler": "Saturn"
+          },
+          {
+            "decan": 3,
+            "ruler": "Jupiter"
+          }
+        ]
+      },
+      {
+        "name": "Scorpio",
+        "symbol": "♏",
+        "element": "Water",
+        "modality": "Fixed",
+        "ruler": "Mars",
+        "date_range": {
+          "start": "10-22",
+          "end": "11-21"
+        },
+        "polarity": "negative",
+        "opposite": "Taurus",
+        "keywords": [
+          "intensity",
+          "transformation",
+          "strategy"
+        ],
+        "decans": [
+          {
+            "decan": 1,
+            "ruler": "Mars"
+          },
+          {
+            "decan": 2,
+            "ruler": "Sun"
+          },
+          {
+            "decan": 3,
+            "ruler": "Venus"
+          }
+        ]
+      },
+      {
+        "name": "Sagittarius",
+        "symbol": "♐",
+        "element": "Fire",
+        "modality": "Mutable",
+        "ruler": "Jupiter",
+        "date_range": {
+          "start": "11-21",
+          "end": "12-21"
+        },
+        "polarity": "positive",
+        "opposite": "Gemini",
+        "keywords": [
+          "vision",
+          "exploration",
+          "philosophy"
+        ],
+        "decans": [
+          {
+            "decan": 1,
+            "ruler": "Mercury"
+          },
+          {
+            "decan": 2,
+            "ruler": "Moon"
+          },
+          {
+            "decan": 3,
+            "ruler": "Saturn"
+          }
+        ]
+      },
+      {
+        "name": "Capricorn",
+        "symbol": "♑",
+        "element": "Earth",
+        "modality": "Cardinal",
+        "ruler": "Saturn",
+        "date_range": {
+          "start": "12-21",
+          "end": "01-19"
+        },
+        "polarity": "negative",
+        "opposite": "Cancer",
+        "keywords": [
+          "discipline",
+          "structure",
+          "long-term focus"
+        ],
+        "decans": [
+          {
+            "decan": 1,
+            "ruler": "Jupiter"
+          },
+          {
+            "decan": 2,
+            "ruler": "Mars"
+          },
+          {
+            "decan": 3,
+            "ruler": "Sun"
+          }
+        ]
+      },
+      {
+        "name": "Aquarius",
+        "symbol": "♒",
+        "element": "Air",
+        "modality": "Fixed",
+        "ruler": "Saturn",
+        "date_range": {
+          "start": "01-19",
+          "end": "02-18"
+        },
+        "polarity": "positive",
+        "opposite": "Leo",
+        "keywords": [
+          "innovation",
+          "community",
+          "detachment"
+        ],
+        "decans": [
+          {
+            "decan": 1,
+            "ruler": "Venus"
+          },
+          {
+            "decan": 2,
+            "ruler": "Mercury"
+          },
+          {
+            "decan": 3,
+            "ruler": "Moon"
+          }
+        ]
+      },
+      {
+        "name": "Pisces",
+        "symbol": "♓",
+        "element": "Water",
+        "modality": "Mutable",
+        "ruler": "Jupiter",
+        "date_range": {
+          "start": "02-18",
+          "end": "03-20"
+        },
+        "polarity": "negative",
+        "opposite": "Virgo",
+        "keywords": [
+          "compassion",
+          "imagination",
+          "dissolution"
+        ],
+        "decans": [
+          {
+            "decan": 1,
+            "ruler": "Saturn"
+          },
+          {
+            "decan": 2,
+            "ruler": "Jupiter"
+          },
+          {
+            "decan": 3,
+            "ruler": "Mars"
+          }
+        ]
+      }
+    ],
+    "planets": [
+      {
+        "name": "Sun",
+        "symbol": "☉",
+        "domain": "Vitality",
+        "keywords": "Identity",
+        "rulership": [
+          "Leo"
+        ],
+        "dignities": {
+          "domicile": [
+            "Leo"
+          ],
+          "exaltation": [
+            "Aries"
+          ],
+          "detriment": [
+            "Aquarius"
+          ],
+          "fall": [
+            "Libra"
+          ]
+        },
+        "orb_degrees": 1.0
+      },
+      {
+        "name": "Moon",
+        "symbol": "☾",
+        "domain": "Emotions",
+        "keywords": "Instinct",
+        "rulership": [
+          "Cancer"
+        ],
+        "dignities": {
+          "domicile": [
+            "Cancer"
+          ],
+          "exaltation": [
+            "Taurus"
+          ],
+          "detriment": [
+            "Capricorn"
+          ],
+          "fall": [
+            "Scorpio"
+          ]
+        },
+        "orb_degrees": 0.8
+      },
+      {
+        "name": "Mercury",
+        "symbol": "☿",
+        "domain": "Communication",
+        "keywords": "Intellect",
+        "rulership": [
+          "Gemini",
+          "Virgo"
+        ],
+        "dignities": {
+          "domicile": [
+            "Gemini",
+            "Virgo"
+          ],
+          "exaltation": [
+            "Virgo"
+          ],
+          "detriment": [
+            "Sagittarius",
+            "Pisces"
+          ],
+          "fall": [
+            "Pisces"
+          ]
+        },
+        "orb_degrees": 0.6
+      },
+      {
+        "name": "Venus",
+        "symbol": "♀",
+        "domain": "Attraction",
+        "keywords": "Harmony",
+        "rulership": [
+          "Taurus",
+          "Libra"
+        ],
+        "dignities": {
+          "domicile": [
+            "Taurus",
+            "Libra"
+          ],
+          "exaltation": [
+            "Pisces"
+          ],
+          "detriment": [
+            "Scorpio",
+            "Aries"
+          ],
+          "fall": [
+            "Virgo"
+          ]
+        },
+        "orb_degrees": 0.7
+      },
+      {
+        "name": "Mars",
+        "symbol": "♂",
+        "domain": "Drive",
+        "keywords": "Action",
+        "rulership": [
+          "Aries",
+          "Scorpio"
+        ],
+        "dignities": {
+          "domicile": [
+            "Aries",
+            "Scorpio"
+          ],
+          "exaltation": [
+            "Capricorn"
+          ],
+          "detriment": [
+            "Libra",
+            "Taurus"
+          ],
+          "fall": [
+            "Cancer"
+          ]
+        },
+        "orb_degrees": 0.9
+      },
+      {
+        "name": "Jupiter",
+        "symbol": "♃",
+        "domain": "Expansion",
+        "keywords": "Wisdom",
+        "rulership": [
+          "Sagittarius",
+          "Pisces"
+        ],
+        "dignities": {
+          "domicile": [
+            "Sagittarius",
+            "Pisces"
+          ],
+          "exaltation": [
+            "Cancer"
+          ],
+          "detriment": [
+            "Gemini",
+            "Virgo"
+          ],
+          "fall": [
+            "Capricorn"
+          ]
+        },
+        "orb_degrees": 1.2
+      },
+      {
+        "name": "Saturn",
+        "symbol": "♄",
+        "domain": "Structure",
+        "keywords": "Discipline",
+        "rulership": [
+          "Capricorn",
+          "Aquarius"
+        ],
+        "dignities": {
+          "domicile": [
+            "Capricorn",
+            "Aquarius"
+          ],
+          "exaltation": [
+            "Libra"
+          ],
+          "detriment": [
+            "Cancer",
+            "Leo"
+          ],
+          "fall": [
+            "Aries"
+          ]
+        },
+        "orb_degrees": 1.1
+      },
+      {
+        "name": "Uranus",
+        "symbol": "♅",
+        "domain": "Innovation",
+        "keywords": "Liberation",
+        "rulership": [
+          "Aquarius"
+        ],
+        "dignities": {
+          "domicile": [
+            "Aquarius"
+          ],
+          "exaltation": [
+            "Scorpio"
+          ],
+          "detriment": [
+            "Leo"
+          ],
+          "fall": [
+            "Taurus"
+          ]
+        },
+        "orb_degrees": 1.3
+      },
+      {
+        "name": "Neptune",
+        "symbol": "♆",
+        "domain": "Vision",
+        "keywords": "Mysticism",
+        "rulership": [
+          "Pisces"
+        ],
+        "dignities": {
+          "domicile": [
+            "Pisces"
+          ],
+          "exaltation": [
+            "Cancer"
+          ],
+          "detriment": [
+            "Virgo"
+          ],
+          "fall": [
+            "Capricorn"
+          ]
+        },
+        "orb_degrees": 1.3
+      },
+      {
+        "name": "Pluto",
+        "symbol": "♇",
+        "domain": "Transformation",
+        "keywords": "Power",
+        "rulership": [
+          "Scorpio"
+        ],
+        "dignities": {
+          "domicile": [
+            "Scorpio"
+          ],
+          "exaltation": [
+            "Leo"
+          ],
+          "detriment": [
+            "Taurus"
+          ],
+          "fall": [
+            "Aquarius"
+          ]
+        },
+        "orb_degrees": 1.4
+      }
+    ],
+    "houses": [
+      {
+        "number": 1,
+        "name": "Self",
+        "alternate_name": "Ascendant",
+        "keywords": [
+          "identity",
+          "approach",
+          "presentation"
+        ],
+        "natural_sign": "Aries"
+      },
+      {
+        "number": 2,
+        "name": "Resources",
+        "alternate_name": "Values",
+        "keywords": [
+          "finances",
+          "possessions",
+          "self-worth"
+        ],
+        "natural_sign": "Taurus"
+      },
+      {
+        "number": 3,
+        "name": "Communication",
+        "alternate_name": "Siblings",
+        "keywords": [
+          "learning",
+          "short trips",
+          "messaging"
+        ],
+        "natural_sign": "Gemini"
+      },
+      {
+        "number": 4,
+        "name": "Home",
+        "alternate_name": "Roots",
+        "keywords": [
+          "family",
+          "foundation",
+          "security"
+        ],
+        "natural_sign": "Cancer"
+      },
+      {
+        "number": 5,
+        "name": "Creativity",
+        "alternate_name": "Pleasure",
+        "keywords": [
+          "romance",
+          "children",
+          "self-expression"
+        ],
+        "natural_sign": "Leo"
+      },
+      {
+        "number": 6,
+        "name": "Service",
+        "alternate_name": "Habits",
+        "keywords": [
+          "work",
+          "health",
+          "routine"
+        ],
+        "natural_sign": "Virgo"
+      },
+      {
+        "number": 7,
+        "name": "Partnership",
+        "alternate_name": "Contracts",
+        "keywords": [
+          "marriage",
+          "alliances",
+          "opposition"
+        ],
+        "natural_sign": "Libra"
+      },
+      {
+        "number": 8,
+        "name": "Shared Resources",
+        "alternate_name": "Transformation",
+        "keywords": [
+          "intimacy",
+          "debt",
+          "alchemy"
+        ],
+        "natural_sign": "Scorpio"
+      },
+      {
+        "number": 9,
+        "name": "Philosophy",
+        "alternate_name": "Long Journeys",
+        "keywords": [
+          "beliefs",
+          "publishing",
+          "higher learning"
+        ],
+        "natural_sign": "Sagittarius"
+      },
+      {
+        "number": 10,
+        "name": "Career",
+        "alternate_name": "Public Standing",
+        "keywords": [
+          "profession",
+          "legacy",
+          "authority"
+        ],
+        "natural_sign": "Capricorn"
+      },
+      {
+        "number": 11,
+        "name": "Community",
+        "alternate_name": "Future",
+        "keywords": [
+          "friends",
+          "networks",
+          "innovation"
+        ],
+        "natural_sign": "Aquarius"
+      },
+      {
+        "number": 12,
+        "name": "Subconscious",
+        "alternate_name": "Completion",
+        "keywords": [
+          "rest",
+          "spirituality",
+          "seclusion"
+        ],
+        "natural_sign": "Pisces"
+      }
+    ],
+    "aspects": [
+      {
+        "name": "conjunction",
+        "angle": 0,
+        "keyword": "merging",
+        "description": "potent union; planets act as one"
+      },
+      {
+        "name": "sextile",
+        "angle": 60,
+        "keyword": "opportunity",
+        "description": "harmonious growth through conscious effort"
+      },
+      {
+        "name": "square",
+        "angle": 90,
+        "keyword": "tension",
+        "description": "dynamic challenge requiring action"
+      },
+      {
+        "name": "trine",
+        "angle": 120,
+        "keyword": "flow",
+        "description": "easy harmony and natural talent"
+      },
+      {
+        "name": "opposition",
+        "angle": 180,
+        "keyword": "polarity",
+        "description": "balancing two ends of a spectrum"
+      },
+      {
+        "name": "quincunx",
+        "angle": 150,
+        "keyword": "adjustment",
+        "description": "need for integration between incompatible energies"
+      }
+    ],
+    "dignity_matrix": {
+      "notes": "Essential dignities summarizing classical relationships.",
+      "table": [
+        {
+          "sign": "Aries",
+          "ruler": "Mars",
+          "exaltation": "Sun",
+          "detriment": "Venus",
+          "fall": "Saturn"
+        },
+        {
+          "sign": "Taurus",
+          "ruler": "Venus",
+          "exaltation": "Moon",
+          "detriment": "Mars",
+          "fall": "Uranus"
+        },
+        {
+          "sign": "Gemini",
+          "ruler": "Mercury",
+          "exaltation": null,
+          "detriment": "Jupiter",
+          "fall": null
+        },
+        {
+          "sign": "Cancer",
+          "ruler": "Moon",
+          "exaltation": "Jupiter",
+          "detriment": "Saturn",
+          "fall": "Mars"
+        },
+        {
+          "sign": "Leo",
+          "ruler": "Sun",
+          "exaltation": null,
+          "detriment": "Saturn",
+          "fall": null
+        },
+        {
+          "sign": "Virgo",
+          "ruler": "Mercury",
+          "exaltation": "Mercury",
+          "detriment": "Jupiter",
+          "fall": "Venus"
+        },
+        {
+          "sign": "Libra",
+          "ruler": "Venus",
+          "exaltation": "Saturn",
+          "detriment": "Mars",
+          "fall": "Sun"
+        },
+        {
+          "sign": "Scorpio",
+          "ruler": "Mars",
+          "exaltation": null,
+          "detriment": "Venus",
+          "fall": "Moon"
+        },
+        {
+          "sign": "Sagittarius",
+          "ruler": "Jupiter",
+          "exaltation": null,
+          "detriment": "Mercury",
+          "fall": null
+        },
+        {
+          "sign": "Capricorn",
+          "ruler": "Saturn",
+          "exaltation": "Mars",
+          "detriment": "Moon",
+          "fall": "Jupiter"
+        },
+        {
+          "sign": "Aquarius",
+          "ruler": "Saturn",
+          "exaltation": null,
+          "detriment": "Sun",
+          "fall": null
+        },
+        {
+          "sign": "Pisces",
+          "ruler": "Jupiter",
+          "exaltation": "Venus",
+          "detriment": "Mercury",
+          "fall": "Mercury"
+        }
+      ]
+    }
+  }
+}

--- a/entities/oracle/predictive_divination_extension/assets/runes_futhark.json
+++ b/entities/oracle/predictive_divination_extension/assets/runes_futhark.json
@@ -1,0 +1,830 @@
+{
+  "elder_futhark": {
+    "metadata": {
+      "sequence": 24,
+      "usage": "First aettir (Fehu-Othala) with upright/merkstave states; blank rune intentionally omitted.",
+      "sources": [
+        "Runic Poem triad synthesis (Anglo-Saxon, Norwegian, Icelandic)",
+        "Ralph Blum public domain keyword concordance"
+      ]
+    },
+    "runes": [
+      {
+        "order": 1,
+        "rune": "Fehu",
+        "glyph": "ᚠ",
+        "phoneme": "f",
+        "translation": "Wealth",
+        "keywords": {
+          "upright": [
+            "prosperity",
+            "earned success",
+            "resource flow"
+          ],
+          "merkstave": [
+            "loss",
+            "stagnation",
+            "blocked assets"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "prosperity",
+            "earned success",
+            "resource flow"
+          ],
+          "merkstave": [
+            "loss",
+            "stagnation",
+            "blocked assets"
+          ]
+        },
+        "elemental_association": {
+          "classical": "fire"
+        }
+      },
+      {
+        "order": 2,
+        "rune": "Uruz",
+        "glyph": "ᚢ",
+        "phoneme": "u",
+        "translation": "Strength",
+        "keywords": {
+          "upright": [
+            "vitality",
+            "endurance",
+            "wild power"
+          ],
+          "merkstave": [
+            "exhaustion",
+            "missed opportunity",
+            "imbalance"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "vitality",
+            "endurance",
+            "wild power"
+          ],
+          "merkstave": [
+            "exhaustion",
+            "missed opportunity",
+            "imbalance"
+          ]
+        },
+        "elemental_association": {
+          "classical": "fire"
+        }
+      },
+      {
+        "order": 3,
+        "rune": "Thurisaz",
+        "glyph": "ᚦ",
+        "phoneme": "th",
+        "translation": "Threshold",
+        "keywords": {
+          "upright": [
+            "defense",
+            "awakening",
+            "strategic action"
+          ],
+          "merkstave": [
+            "recklessness",
+            "vindictiveness",
+            "obsession"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "defense",
+            "awakening",
+            "strategic action"
+          ],
+          "merkstave": [
+            "recklessness",
+            "vindictiveness",
+            "obsession"
+          ]
+        },
+        "elemental_association": {
+          "classical": "fire"
+        }
+      },
+      {
+        "order": 4,
+        "rune": "Ansuz",
+        "glyph": "ᚨ",
+        "phoneme": "a",
+        "translation": "Signals",
+        "keywords": {
+          "upright": [
+            "communication",
+            "divine insight",
+            "mentorship"
+          ],
+          "merkstave": [
+            "miscommunication",
+            "deception",
+            "confusion"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "communication",
+            "divine insight",
+            "mentorship"
+          ],
+          "merkstave": [
+            "miscommunication",
+            "deception",
+            "confusion"
+          ]
+        },
+        "elemental_association": {
+          "classical": "air"
+        }
+      },
+      {
+        "order": 5,
+        "rune": "Raidho",
+        "glyph": "ᚱ",
+        "phoneme": "r",
+        "translation": "Journey",
+        "keywords": {
+          "upright": [
+            "movement",
+            "aligned progress",
+            "ritual"
+          ],
+          "merkstave": [
+            "delays",
+            "detours",
+            "breakdown"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "movement",
+            "aligned progress",
+            "ritual"
+          ],
+          "merkstave": [
+            "delays",
+            "detours",
+            "breakdown"
+          ]
+        },
+        "elemental_association": {
+          "classical": "fire"
+        }
+      },
+      {
+        "order": 6,
+        "rune": "Kenaz",
+        "glyph": "ᚲ",
+        "phoneme": "k",
+        "translation": "Torch",
+        "keywords": {
+          "upright": [
+            "illumination",
+            "craft",
+            "clarity"
+          ],
+          "merkstave": [
+            "burnout",
+            "creative block",
+            "smoldering resentments"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "illumination",
+            "craft",
+            "clarity"
+          ],
+          "merkstave": [
+            "burnout",
+            "creative block",
+            "smoldering resentments"
+          ]
+        },
+        "elemental_association": {
+          "classical": "air"
+        }
+      },
+      {
+        "order": 7,
+        "rune": "Gebo",
+        "glyph": "ᚷ",
+        "phoneme": "g",
+        "translation": "Gift",
+        "keywords": {
+          "upright": [
+            "exchange",
+            "balance",
+            "contracts"
+          ],
+          "merkstave": [
+            "obligation",
+            "strings attached",
+            "imbalance"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "exchange",
+            "balance",
+            "contracts"
+          ],
+          "merkstave": [
+            "obligation",
+            "strings attached",
+            "imbalance"
+          ]
+        },
+        "elemental_association": {
+          "classical": "earth"
+        }
+      },
+      {
+        "order": 8,
+        "rune": "Wunjo",
+        "glyph": "ᚹ",
+        "phoneme": "w",
+        "translation": "Joy",
+        "keywords": {
+          "upright": [
+            "harmony",
+            "success",
+            "community"
+          ],
+          "merkstave": [
+            "discord",
+            "overindulgence",
+            "alienation"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "harmony",
+            "success",
+            "community"
+          ],
+          "merkstave": [
+            "discord",
+            "overindulgence",
+            "alienation"
+          ]
+        },
+        "elemental_association": {
+          "classical": "water"
+        }
+      },
+      {
+        "order": 9,
+        "rune": "Hagalaz",
+        "glyph": "ᚺ",
+        "phoneme": "h",
+        "translation": "Disruption",
+        "keywords": {
+          "upright": [
+            "necessary change",
+            "catalyst",
+            "weathering storms"
+          ],
+          "merkstave": [
+            "chaos",
+            "crisis",
+            "fragility"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "necessary change",
+            "catalyst",
+            "weathering storms"
+          ],
+          "merkstave": [
+            "chaos",
+            "crisis",
+            "fragility"
+          ]
+        },
+        "elemental_association": {
+          "classical": "water"
+        }
+      },
+      {
+        "order": 10,
+        "rune": "Nauthiz",
+        "glyph": "ᚾ",
+        "phoneme": "n",
+        "translation": "Need",
+        "keywords": {
+          "upright": [
+            "discipline",
+            "constraint",
+            "resourcefulness"
+          ],
+          "merkstave": [
+            "frustration",
+            "obsession",
+            "hardship"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "discipline",
+            "constraint",
+            "resourcefulness"
+          ],
+          "merkstave": [
+            "frustration",
+            "obsession",
+            "hardship"
+          ]
+        },
+        "elemental_association": {
+          "classical": "earth"
+        }
+      },
+      {
+        "order": 11,
+        "rune": "Isa",
+        "glyph": "ᛁ",
+        "phoneme": "i",
+        "translation": "Stillness",
+        "keywords": {
+          "upright": [
+            "pause",
+            "concentration",
+            "preservation"
+          ],
+          "merkstave": [
+            "rigidity",
+            "stagnation",
+            "numbing"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "pause",
+            "concentration",
+            "preservation"
+          ],
+          "merkstave": [
+            "rigidity",
+            "stagnation",
+            "numbing"
+          ]
+        },
+        "elemental_association": {
+          "classical": "earth"
+        }
+      },
+      {
+        "order": 12,
+        "rune": "Jera",
+        "glyph": "ᛃ",
+        "phoneme": "j",
+        "translation": "Harvest",
+        "keywords": {
+          "upright": [
+            "cycles",
+            "reward",
+            "timing"
+          ],
+          "merkstave": [
+            "delay",
+            "impatience",
+            "premature action"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "cycles",
+            "reward",
+            "timing"
+          ],
+          "merkstave": [
+            "delay",
+            "impatience",
+            "premature action"
+          ]
+        },
+        "elemental_association": {
+          "classical": "earth"
+        }
+      },
+      {
+        "order": 13,
+        "rune": "Eihwaz",
+        "glyph": "ᛇ",
+        "phoneme": "ei",
+        "translation": "Axis",
+        "keywords": {
+          "upright": [
+            "resilience",
+            "initiation",
+            "inner strength"
+          ],
+          "merkstave": [
+            "conflict",
+            "aversion",
+            "sacrifice"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "resilience",
+            "initiation",
+            "inner strength"
+          ],
+          "merkstave": [
+            "conflict",
+            "aversion",
+            "sacrifice"
+          ]
+        },
+        "elemental_association": {
+          "classical": "earth"
+        }
+      },
+      {
+        "order": 14,
+        "rune": "Perthro",
+        "glyph": "ᛈ",
+        "phoneme": "p",
+        "translation": "Mystery",
+        "keywords": {
+          "upright": [
+            "chance",
+            "divination",
+            "hidden pattern"
+          ],
+          "merkstave": [
+            "secrets",
+            "gambling",
+            "stagnant fate"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "chance",
+            "divination",
+            "hidden pattern"
+          ],
+          "merkstave": [
+            "secrets",
+            "gambling",
+            "stagnant fate"
+          ]
+        },
+        "elemental_association": {
+          "classical": "water"
+        }
+      },
+      {
+        "order": 15,
+        "rune": "Algiz",
+        "glyph": "ᛉ",
+        "phoneme": "z",
+        "translation": "Guard",
+        "keywords": {
+          "upright": [
+            "protection",
+            "alertness",
+            "sanctuary"
+          ],
+          "merkstave": [
+            "vulnerability",
+            "misplaced trust",
+            "over-defensiveness"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "protection",
+            "alertness",
+            "sanctuary"
+          ],
+          "merkstave": [
+            "vulnerability",
+            "misplaced trust",
+            "over-defensiveness"
+          ]
+        },
+        "elemental_association": {
+          "classical": "earth"
+        }
+      },
+      {
+        "order": 16,
+        "rune": "Sowilo",
+        "glyph": "ᛋ",
+        "phoneme": "s",
+        "translation": "Sun",
+        "keywords": {
+          "upright": [
+            "victory",
+            "wholeness",
+            "radiance"
+          ],
+          "merkstave": [
+            "arrogance",
+            "ego burn",
+            "carelessness"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "victory",
+            "wholeness",
+            "radiance"
+          ],
+          "merkstave": [
+            "arrogance",
+            "ego burn",
+            "carelessness"
+          ]
+        },
+        "elemental_association": {
+          "classical": "air"
+        }
+      },
+      {
+        "order": 17,
+        "rune": "Tiwaz",
+        "glyph": "ᛏ",
+        "phoneme": "t",
+        "translation": "Justice",
+        "keywords": {
+          "upright": [
+            "courage",
+            "strategy",
+            "victory"
+          ],
+          "merkstave": [
+            "impulsiveness",
+            "failed leadership",
+            "stubbornness"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "courage",
+            "strategy",
+            "victory"
+          ],
+          "merkstave": [
+            "impulsiveness",
+            "failed leadership",
+            "stubbornness"
+          ]
+        },
+        "elemental_association": {
+          "classical": "fire"
+        }
+      },
+      {
+        "order": 18,
+        "rune": "Berkano",
+        "glyph": "ᛒ",
+        "phoneme": "b",
+        "translation": "Birch",
+        "keywords": {
+          "upright": [
+            "growth",
+            "nurturing",
+            "renewal"
+          ],
+          "merkstave": [
+            "stagnation",
+            "smothering",
+            "unpreparedness"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "growth",
+            "nurturing",
+            "renewal"
+          ],
+          "merkstave": [
+            "stagnation",
+            "smothering",
+            "unpreparedness"
+          ]
+        },
+        "elemental_association": {
+          "classical": "earth"
+        }
+      },
+      {
+        "order": 19,
+        "rune": "Ehwaz",
+        "glyph": "ᛖ",
+        "phoneme": "e",
+        "translation": "Trust",
+        "keywords": {
+          "upright": [
+            "partnership",
+            "mobility",
+            "cooperation"
+          ],
+          "merkstave": [
+            "disharmony",
+            "restlessness",
+            "detachment"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "partnership",
+            "mobility",
+            "cooperation"
+          ],
+          "merkstave": [
+            "disharmony",
+            "restlessness",
+            "detachment"
+          ]
+        },
+        "elemental_association": {
+          "classical": "earth"
+        }
+      },
+      {
+        "order": 20,
+        "rune": "Mannaz",
+        "glyph": "ᛗ",
+        "phoneme": "m",
+        "translation": "Humankind",
+        "keywords": {
+          "upright": [
+            "self-awareness",
+            "interdependence",
+            "culture"
+          ],
+          "merkstave": [
+            "isolation",
+            "egoism",
+            "bias"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "self-awareness",
+            "interdependence",
+            "culture"
+          ],
+          "merkstave": [
+            "isolation",
+            "egoism",
+            "bias"
+          ]
+        },
+        "elemental_association": {
+          "classical": "earth"
+        }
+      },
+      {
+        "order": 21,
+        "rune": "Laguz",
+        "glyph": "ᛚ",
+        "phoneme": "l",
+        "translation": "Flow",
+        "keywords": {
+          "upright": [
+            "intuition",
+            "dreaming",
+            "adaptive movement"
+          ],
+          "merkstave": [
+            "fear",
+            "overwhelm",
+            "doubt"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "intuition",
+            "dreaming",
+            "adaptive movement"
+          ],
+          "merkstave": [
+            "fear",
+            "overwhelm",
+            "doubt"
+          ]
+        },
+        "elemental_association": {
+          "classical": "water"
+        }
+      },
+      {
+        "order": 22,
+        "rune": "Ingwaz",
+        "glyph": "ᛜ",
+        "phoneme": "ng",
+        "translation": "Seed",
+        "keywords": {
+          "upright": [
+            "gestation",
+            "potential",
+            "rest before action"
+          ],
+          "merkstave": [
+            "stagnation",
+            "refusal to release",
+            "entropy"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "gestation",
+            "potential",
+            "rest before action"
+          ],
+          "merkstave": [
+            "stagnation",
+            "refusal to release",
+            "entropy"
+          ]
+        },
+        "elemental_association": {
+          "classical": "earth"
+        }
+      },
+      {
+        "order": 23,
+        "rune": "Dagaz",
+        "glyph": "ᛞ",
+        "phoneme": "d",
+        "translation": "Breakthrough",
+        "keywords": {
+          "upright": [
+            "transformation",
+            "clarity",
+            "resolution"
+          ],
+          "merkstave": [
+            "resistance",
+            "abrupt endings",
+            "disorientation"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "transformation",
+            "clarity",
+            "resolution"
+          ],
+          "merkstave": [
+            "resistance",
+            "abrupt endings",
+            "disorientation"
+          ]
+        },
+        "elemental_association": {
+          "classical": "air"
+        }
+      },
+      {
+        "order": 24,
+        "rune": "Othala",
+        "glyph": "ᛟ",
+        "phoneme": "o",
+        "translation": "Heritage",
+        "keywords": {
+          "upright": [
+            "legacy",
+            "home",
+            "inheritance"
+          ],
+          "merkstave": [
+            "loss",
+            "rigid tradition",
+            "division"
+          ]
+        },
+        "meanings": {
+          "upright": [
+            "legacy",
+            "home",
+            "inheritance"
+          ],
+          "merkstave": [
+            "loss",
+            "rigid tradition",
+            "division"
+          ]
+        },
+        "elemental_association": {
+          "classical": "earth"
+        }
+      }
+    ]
+  }
+}

--- a/entities/oracle/predictive_divination_extension/assets/sefirot.json
+++ b/entities/oracle/predictive_divination_extension/assets/sefirot.json
@@ -1,0 +1,506 @@
+{
+  "sefirot": {
+    "metadata": {
+      "tradition": "Hermetic Qabalah (Golden Dawn correspondences)",
+      "sources": [
+        "Mathers' 'Kabbalah Unveiled' (public domain)",
+        "Golden Dawn 777 tables"
+      ]
+    },
+    "tree": [
+      {
+        "number": 1,
+        "name": "Keter",
+        "hebrew": "כתר",
+        "titles": [
+          "Crown",
+          "The Primal Point"
+        ],
+        "pillar": "Middle",
+        "element": "Spirit",
+        "planet": "Primum Mobile",
+        "archangel": "Metatron",
+        "angelic_order": "Chayoth ha-Qadesh",
+        "keywords": {
+          "principles": [
+            "divine will",
+            "unity",
+            "source"
+          ],
+          "shadow": [
+            "spiritual bypassing",
+            "disconnection from embodiment"
+          ]
+        },
+        "associated_paths": [
+          11,
+          12,
+          13
+        ]
+      },
+      {
+        "number": 2,
+        "name": "Chokmah",
+        "hebrew": "חכמה",
+        "titles": [
+          "Wisdom",
+          "Abba"
+        ],
+        "pillar": "Right",
+        "element": "Fire",
+        "planet": "Zodiac (Mazloth)",
+        "archangel": "Ratziel",
+        "angelic_order": "Auphanim",
+        "keywords": {
+          "principles": [
+            "creative impulse",
+            "initiative",
+            "formative force"
+          ],
+          "shadow": [
+            "impulsivity",
+            "unchecked expansion"
+          ]
+        },
+        "associated_paths": [
+          11,
+          14,
+          15,
+          16
+        ]
+      },
+      {
+        "number": 3,
+        "name": "Binah",
+        "hebrew": "בינה",
+        "titles": [
+          "Understanding",
+          "Ima"
+        ],
+        "pillar": "Left",
+        "element": "Water",
+        "planet": "Saturn",
+        "archangel": "Tzaphkiel",
+        "angelic_order": "Aralim",
+        "keywords": {
+          "principles": [
+            "structure",
+            "comprehension",
+            "limitation"
+          ],
+          "shadow": [
+            "rigidity",
+            "sorrow",
+            "stagnation"
+          ]
+        },
+        "associated_paths": [
+          12,
+          14,
+          17,
+          18
+        ]
+      },
+      {
+        "number": 4,
+        "name": "Chesed",
+        "hebrew": "חסד",
+        "titles": [
+          "Mercy",
+          "Loving-Kindness"
+        ],
+        "pillar": "Right",
+        "element": "Water",
+        "planet": "Jupiter",
+        "archangel": "Tzadkiel",
+        "angelic_order": "Chasmalim",
+        "keywords": {
+          "principles": [
+            "benevolence",
+            "expansion",
+            "faith"
+          ],
+          "shadow": [
+            "indulgence",
+            "laxity"
+          ]
+        },
+        "associated_paths": [
+          16,
+          19,
+          20,
+          21
+        ]
+      },
+      {
+        "number": 5,
+        "name": "Geburah",
+        "hebrew": "גבורה",
+        "titles": [
+          "Severity",
+          "Strength"
+        ],
+        "pillar": "Left",
+        "element": "Fire",
+        "planet": "Mars",
+        "archangel": "Khamael",
+        "angelic_order": "Seraphim",
+        "keywords": {
+          "principles": [
+            "discipline",
+            "courage",
+            "boundaries"
+          ],
+          "shadow": [
+            "cruelty",
+            "rigid judgement"
+          ]
+        },
+        "associated_paths": [
+          18,
+          19,
+          22,
+          23
+        ]
+      },
+      {
+        "number": 6,
+        "name": "Tiphareth",
+        "hebrew": "תפארת",
+        "titles": [
+          "Beauty",
+          "Harmonious Balance"
+        ],
+        "pillar": "Middle",
+        "element": "Air",
+        "planet": "Sun",
+        "archangel": "Raphael",
+        "angelic_order": "Malachim",
+        "keywords": {
+          "principles": [
+            "integration",
+            "sacrifice",
+            "illumination"
+          ],
+          "shadow": [
+            "martyrdom",
+            "self-importance"
+          ]
+        },
+        "associated_paths": [
+          13,
+          15,
+          17,
+          20,
+          22,
+          24,
+          25,
+          26
+        ]
+      },
+      {
+        "number": 7,
+        "name": "Netzach",
+        "hebrew": "נצח",
+        "titles": [
+          "Victory",
+          "Eternity"
+        ],
+        "pillar": "Right",
+        "element": "Fire",
+        "planet": "Venus",
+        "archangel": "Haniel",
+        "angelic_order": "Elohim",
+        "keywords": {
+          "principles": [
+            "endurance",
+            "desire",
+            "artistry"
+          ],
+          "shadow": [
+            "overindulgence",
+            "avoidance"
+          ]
+        },
+        "associated_paths": [
+          21,
+          24,
+          27,
+          28,
+          29
+        ]
+      },
+      {
+        "number": 8,
+        "name": "Hod",
+        "hebrew": "הוד",
+        "titles": [
+          "Splendor",
+          "Glory"
+        ],
+        "pillar": "Left",
+        "element": "Water",
+        "planet": "Mercury",
+        "archangel": "Michael",
+        "angelic_order": "Beni Elohim",
+        "keywords": {
+          "principles": [
+            "analysis",
+            "communication",
+            "ritual"
+          ],
+          "shadow": [
+            "over-intellectualization",
+            "dishonesty"
+          ]
+        },
+        "associated_paths": [
+          23,
+          26,
+          27,
+          30,
+          31
+        ]
+      },
+      {
+        "number": 9,
+        "name": "Yesod",
+        "hebrew": "יסוד",
+        "titles": [
+          "Foundation",
+          "The Machinery"
+        ],
+        "pillar": "Middle",
+        "element": "Air",
+        "planet": "Moon",
+        "archangel": "Gabriel",
+        "angelic_order": "Kerubim",
+        "keywords": {
+          "principles": [
+            "dreaming",
+            "imagination",
+            "interface"
+          ],
+          "shadow": [
+            "illusion",
+            "escapism"
+          ]
+        },
+        "associated_paths": [
+          25,
+          28,
+          30,
+          32
+        ]
+      },
+      {
+        "number": 10,
+        "name": "Malkuth",
+        "hebrew": "מלכות",
+        "titles": [
+          "Kingdom",
+          "Shekinah"
+        ],
+        "pillar": "Middle",
+        "element": "Earth",
+        "planet": "Earth",
+        "archangel": "Sandalphon",
+        "angelic_order": "Ashim",
+        "keywords": {
+          "principles": [
+            "manifestation",
+            "stewardship",
+            "grounding"
+          ],
+          "shadow": [
+            "materialism",
+            "disconnection from source"
+          ]
+        },
+        "associated_paths": [
+          29,
+          31,
+          32
+        ]
+      }
+    ],
+    "paths": [
+      {
+        "number": 11,
+        "letter": "Aleph",
+        "from": "Keter",
+        "to": "Chokmah",
+        "astrology": "Air",
+        "tarot": "The Fool"
+      },
+      {
+        "number": 12,
+        "letter": "Beth",
+        "from": "Keter",
+        "to": "Binah",
+        "astrology": "Mercury",
+        "tarot": "The Magician"
+      },
+      {
+        "number": 13,
+        "letter": "Gimel",
+        "from": "Keter",
+        "to": "Tiphareth",
+        "astrology": "Moon",
+        "tarot": "The High Priestess"
+      },
+      {
+        "number": 14,
+        "letter": "Daleth",
+        "from": "Chokmah",
+        "to": "Binah",
+        "astrology": "Venus",
+        "tarot": "The Empress"
+      },
+      {
+        "number": 15,
+        "letter": "Heh",
+        "from": "Chokmah",
+        "to": "Tiphareth",
+        "astrology": "Aries",
+        "tarot": "The Emperor"
+      },
+      {
+        "number": 16,
+        "letter": "Vav",
+        "from": "Chokmah",
+        "to": "Chesed",
+        "astrology": "Taurus",
+        "tarot": "The Hierophant"
+      },
+      {
+        "number": 17,
+        "letter": "Zain",
+        "from": "Binah",
+        "to": "Tiphareth",
+        "astrology": "Gemini",
+        "tarot": "The Lovers"
+      },
+      {
+        "number": 18,
+        "letter": "Cheth",
+        "from": "Binah",
+        "to": "Geburah",
+        "astrology": "Cancer",
+        "tarot": "The Chariot"
+      },
+      {
+        "number": 19,
+        "letter": "Teth",
+        "from": "Chesed",
+        "to": "Geburah",
+        "astrology": "Leo",
+        "tarot": "Strength"
+      },
+      {
+        "number": 20,
+        "letter": "Yod",
+        "from": "Chesed",
+        "to": "Tiphareth",
+        "astrology": "Virgo",
+        "tarot": "The Hermit"
+      },
+      {
+        "number": 21,
+        "letter": "Kaph",
+        "from": "Chesed",
+        "to": "Netzach",
+        "astrology": "Jupiter",
+        "tarot": "Wheel of Fortune"
+      },
+      {
+        "number": 22,
+        "letter": "Lamed",
+        "from": "Geburah",
+        "to": "Tiphareth",
+        "astrology": "Libra",
+        "tarot": "Justice"
+      },
+      {
+        "number": 23,
+        "letter": "Mem",
+        "from": "Geburah",
+        "to": "Hod",
+        "astrology": "Water",
+        "tarot": "The Hanged Man"
+      },
+      {
+        "number": 24,
+        "letter": "Nun",
+        "from": "Tiphareth",
+        "to": "Netzach",
+        "astrology": "Scorpio",
+        "tarot": "Death"
+      },
+      {
+        "number": 25,
+        "letter": "Samekh",
+        "from": "Tiphareth",
+        "to": "Yesod",
+        "astrology": "Sagittarius",
+        "tarot": "Temperance"
+      },
+      {
+        "number": 26,
+        "letter": "Ayin",
+        "from": "Tiphareth",
+        "to": "Hod",
+        "astrology": "Capricorn",
+        "tarot": "The Devil"
+      },
+      {
+        "number": 27,
+        "letter": "Peh",
+        "from": "Netzach",
+        "to": "Hod",
+        "astrology": "Mars",
+        "tarot": "The Tower"
+      },
+      {
+        "number": 28,
+        "letter": "Tzaddi",
+        "from": "Netzach",
+        "to": "Yesod",
+        "astrology": "Aquarius",
+        "tarot": "The Star"
+      },
+      {
+        "number": 29,
+        "letter": "Qoph",
+        "from": "Netzach",
+        "to": "Malkuth",
+        "astrology": "Pisces",
+        "tarot": "The Moon"
+      },
+      {
+        "number": 30,
+        "letter": "Resh",
+        "from": "Hod",
+        "to": "Yesod",
+        "astrology": "Sun",
+        "tarot": "The Sun"
+      },
+      {
+        "number": 31,
+        "letter": "Shin",
+        "from": "Hod",
+        "to": "Malkuth",
+        "astrology": "Fire",
+        "tarot": "Judgement"
+      },
+      {
+        "number": 32,
+        "letter": "Tau",
+        "from": "Yesod",
+        "to": "Malkuth",
+        "astrology": "Saturn",
+        "tarot": "The World"
+      }
+    ]
+  }
+}

--- a/entities/oracle/predictive_divination_extension/assets/tarot_expansions.json
+++ b/entities/oracle/predictive_divination_extension/assets/tarot_expansions.json
@@ -1,0 +1,539 @@
+{
+  "expansions": {
+    "metadata": {
+      "version": "2025-09-21",
+      "sources": [
+        "Thoth tarot correspondences compiled from Aleister Crowley's Book of Thoth (public domain)",
+        "Tarot de Marseille numbering harmonized via Camoin/Jodorowsky restoration notes",
+        "Common contemporary spread patterns referenced from BOTA teaching decks"
+      ],
+      "notes": "Provides overlay material for decks and practices that diverge from the Rider–Waite–Smith baseline."
+    },
+    "alternate_numbering": {
+      "justice_strength_swap": {
+        "description": "Strength and Justice swap numbering between Waite/Smith (VIII/XI) and Marseille/Thoth (XI/VIII).",
+        "marseille": {
+          "strength": 11,
+          "justice": 8
+        },
+        "rws": {
+          "strength": 8,
+          "justice": 11
+        },
+        "thoth": {
+          "lust": 11,
+          "adjustment": 8
+        }
+      },
+      "unnumbered_fool": {
+        "description": "Some systems place the Fool at the end rather than at zero.",
+        "marseille": "Unnumbered, often placed between Judgement and World",
+        "thoth": "Designated as Atu 0 but travels through the paths"
+      }
+    },
+    "alternate_titles": {
+      "thoth": {
+        "Justice": "Adjustment",
+        "Strength": "Lust",
+        "Judgement": "The Aeon",
+        "Wheel of Fortune": "Fortune",
+        "The World": "The Universe"
+      },
+      "marseille": {
+        "The High Priestess": "La Papesse",
+        "The Hierophant": "Le Pape",
+        "The Lovers": "L'Amoureux",
+        "The Hanged Man": "Le Pendu"
+      }
+    },
+    "elemental_dignities": {
+      "policy": "Used for advanced spread interpretation; supportive elements amplify while hostile ones diminish.",
+      "matrix": {
+        "fire": {
+          "supportive": [
+            "air"
+          ],
+          "neutral": [
+            "fire",
+            "water"
+          ],
+          "hostile": [
+            "earth"
+          ]
+        },
+        "water": {
+          "supportive": [
+            "earth"
+          ],
+          "neutral": [
+            "water",
+            "air"
+          ],
+          "hostile": [
+            "fire"
+          ]
+        },
+        "air": {
+          "supportive": [
+            "fire"
+          ],
+          "neutral": [
+            "air",
+            "water"
+          ],
+          "hostile": [
+            "earth"
+          ]
+        },
+        "earth": {
+          "supportive": [
+            "water"
+          ],
+          "neutral": [
+            "earth",
+            "fire"
+          ],
+          "hostile": [
+            "air"
+          ]
+        }
+      }
+    },
+    "decans_extended": {
+      "description": "36 decans with ruling planets following the Golden Dawn schema; used for time-based spreads.",
+      "table": [
+        {
+          "decan": 1,
+          "sign": "Aries",
+          "start_degree": 0,
+          "end_degree": 10,
+          "ruler": "Mars"
+        },
+        {
+          "decan": 2,
+          "sign": "Aries",
+          "start_degree": 10,
+          "end_degree": 20,
+          "ruler": "Sun"
+        },
+        {
+          "decan": 3,
+          "sign": "Aries",
+          "start_degree": 20,
+          "end_degree": 30,
+          "ruler": "Venus"
+        },
+        {
+          "decan": 4,
+          "sign": "Taurus",
+          "start_degree": 0,
+          "end_degree": 10,
+          "ruler": "Mercury"
+        },
+        {
+          "decan": 5,
+          "sign": "Taurus",
+          "start_degree": 10,
+          "end_degree": 20,
+          "ruler": "Moon"
+        },
+        {
+          "decan": 6,
+          "sign": "Taurus",
+          "start_degree": 20,
+          "end_degree": 30,
+          "ruler": "Saturn"
+        },
+        {
+          "decan": 7,
+          "sign": "Gemini",
+          "start_degree": 0,
+          "end_degree": 10,
+          "ruler": "Jupiter"
+        },
+        {
+          "decan": 8,
+          "sign": "Gemini",
+          "start_degree": 10,
+          "end_degree": 20,
+          "ruler": "Mars"
+        },
+        {
+          "decan": 9,
+          "sign": "Gemini",
+          "start_degree": 20,
+          "end_degree": 30,
+          "ruler": "Sun"
+        },
+        {
+          "decan": 10,
+          "sign": "Cancer",
+          "start_degree": 0,
+          "end_degree": 10,
+          "ruler": "Venus"
+        },
+        {
+          "decan": 11,
+          "sign": "Cancer",
+          "start_degree": 10,
+          "end_degree": 20,
+          "ruler": "Mercury"
+        },
+        {
+          "decan": 12,
+          "sign": "Cancer",
+          "start_degree": 20,
+          "end_degree": 30,
+          "ruler": "Moon"
+        },
+        {
+          "decan": 13,
+          "sign": "Leo",
+          "start_degree": 0,
+          "end_degree": 10,
+          "ruler": "Saturn"
+        },
+        {
+          "decan": 14,
+          "sign": "Leo",
+          "start_degree": 10,
+          "end_degree": 20,
+          "ruler": "Jupiter"
+        },
+        {
+          "decan": 15,
+          "sign": "Leo",
+          "start_degree": 20,
+          "end_degree": 30,
+          "ruler": "Mars"
+        },
+        {
+          "decan": 16,
+          "sign": "Virgo",
+          "start_degree": 0,
+          "end_degree": 10,
+          "ruler": "Sun"
+        },
+        {
+          "decan": 17,
+          "sign": "Virgo",
+          "start_degree": 10,
+          "end_degree": 20,
+          "ruler": "Venus"
+        },
+        {
+          "decan": 18,
+          "sign": "Virgo",
+          "start_degree": 20,
+          "end_degree": 30,
+          "ruler": "Mercury"
+        },
+        {
+          "decan": 19,
+          "sign": "Libra",
+          "start_degree": 0,
+          "end_degree": 10,
+          "ruler": "Moon"
+        },
+        {
+          "decan": 20,
+          "sign": "Libra",
+          "start_degree": 10,
+          "end_degree": 20,
+          "ruler": "Saturn"
+        },
+        {
+          "decan": 21,
+          "sign": "Libra",
+          "start_degree": 20,
+          "end_degree": 30,
+          "ruler": "Jupiter"
+        },
+        {
+          "decan": 22,
+          "sign": "Scorpio",
+          "start_degree": 0,
+          "end_degree": 10,
+          "ruler": "Mars"
+        },
+        {
+          "decan": 23,
+          "sign": "Scorpio",
+          "start_degree": 10,
+          "end_degree": 20,
+          "ruler": "Sun"
+        },
+        {
+          "decan": 24,
+          "sign": "Scorpio",
+          "start_degree": 20,
+          "end_degree": 30,
+          "ruler": "Venus"
+        },
+        {
+          "decan": 25,
+          "sign": "Sagittarius",
+          "start_degree": 0,
+          "end_degree": 10,
+          "ruler": "Mercury"
+        },
+        {
+          "decan": 26,
+          "sign": "Sagittarius",
+          "start_degree": 10,
+          "end_degree": 20,
+          "ruler": "Moon"
+        },
+        {
+          "decan": 27,
+          "sign": "Sagittarius",
+          "start_degree": 20,
+          "end_degree": 30,
+          "ruler": "Saturn"
+        },
+        {
+          "decan": 28,
+          "sign": "Capricorn",
+          "start_degree": 0,
+          "end_degree": 10,
+          "ruler": "Jupiter"
+        },
+        {
+          "decan": 29,
+          "sign": "Capricorn",
+          "start_degree": 10,
+          "end_degree": 20,
+          "ruler": "Mars"
+        },
+        {
+          "decan": 30,
+          "sign": "Capricorn",
+          "start_degree": 20,
+          "end_degree": 30,
+          "ruler": "Sun"
+        },
+        {
+          "decan": 31,
+          "sign": "Aquarius",
+          "start_degree": 0,
+          "end_degree": 10,
+          "ruler": "Venus"
+        },
+        {
+          "decan": 32,
+          "sign": "Aquarius",
+          "start_degree": 10,
+          "end_degree": 20,
+          "ruler": "Mercury"
+        },
+        {
+          "decan": 33,
+          "sign": "Aquarius",
+          "start_degree": 20,
+          "end_degree": 30,
+          "ruler": "Moon"
+        },
+        {
+          "decan": 34,
+          "sign": "Pisces",
+          "start_degree": 0,
+          "end_degree": 10,
+          "ruler": "Saturn"
+        },
+        {
+          "decan": 35,
+          "sign": "Pisces",
+          "start_degree": 10,
+          "end_degree": 20,
+          "ruler": "Jupiter"
+        },
+        {
+          "decan": 36,
+          "sign": "Pisces",
+          "start_degree": 20,
+          "end_degree": 30,
+          "ruler": "Mars"
+        }
+      ]
+    },
+    "spreads": {
+      "three_card": {
+        "layout": [
+          "past",
+          "present",
+          "future"
+        ],
+        "notes": "Core spread used for rapid diagnostics; can be remapped to situation/obstacle/advice."
+      },
+      "celtic_cross": {
+        "layout": [
+          "significator",
+          "crossing",
+          "foundation",
+          "recent_past",
+          "crown",
+          "near_future",
+          "self",
+          "environment",
+          "hopes_fears",
+          "outcome"
+        ],
+        "notes": "Ten-card classical spread per Waite with positional modifiers for elemental dignities."
+      },
+      "horseshoe": {
+        "layout": [
+          "past",
+          "present",
+          "future",
+          "advice",
+          "external_influences",
+          "hopes_fears",
+          "final_outcome"
+        ],
+        "notes": "Seven-card curve optimized for strategic planning queries."
+      },
+      "relationship_bridge": {
+        "layout": [
+          "querent_state",
+          "querent_needs",
+          "bridge",
+          "partner_state",
+          "partner_needs",
+          "shared_future"
+        ],
+        "notes": "Six-card configuration for interpersonal insight; integrates elemental dignity weighting."
+      }
+    },
+    "deck_integrations": {
+      "thoth": {
+        "majors": {
+          "The Fool": {
+            "hebrew": "Aleph",
+            "element": "Air",
+            "notes": "Atu 0 retains elemental Air but includes Uranian undertones."
+          },
+          "The Magus": {
+            "hebrew": "Beth",
+            "element": "Mercury",
+            "notes": "Multiple Magus variations permitted in some printings."
+          },
+          "The Priestess": {
+            "hebrew": "Gimel",
+            "element": "Moon",
+            "notes": "Combines lunar gatekeeping with camel symbolism."
+          },
+          "The Empress": {
+            "hebrew": "Daleth",
+            "element": "Venus",
+            "notes": "Portrayed with the bees and doves of alchemical union."
+          },
+          "The Emperor": {
+            "hebrew": "Tzaddi",
+            "element": "Aries",
+            "notes": "Crowley swaps Tzaddi and Heh placements compared to Golden Dawn."
+          },
+          "The Hierophant": {
+            "hebrew": "Vav",
+            "element": "Taurus",
+            "notes": "Ceremonial magick emphasis with four kerubs."
+          },
+          "The Lovers": {
+            "hebrew": "Zain",
+            "element": "Gemini",
+            "notes": "Depicts alchemical marriage via royal wedding."
+          },
+          "The Chariot": {
+            "hebrew": "Cheth",
+            "element": "Cancer",
+            "notes": "Sphinx-driven chariot referencing Grail mysteries."
+          },
+          "Adjustment": {
+            "hebrew": "Lamed",
+            "element": "Libra",
+            "notes": "Justice renamed to stress dynamic equilibrium."
+          },
+          "The Hermit": {
+            "hebrew": "Yod",
+            "element": "Virgo",
+            "notes": "Orphic egg and Cerberus motifs illustrate initiation."
+          },
+          "Fortune": {
+            "hebrew": "Kaph",
+            "element": "Jupiter",
+            "notes": "Sphinx, Hermanubis, and Typhon rotate the wheel."
+          },
+          "Lust": {
+            "hebrew": "Teth",
+            "element": "Leo",
+            "notes": "Strength renamed to celebrate ecstatic courage."
+          },
+          "The Hanged Man": {
+            "hebrew": "Mem",
+            "element": "Water",
+            "notes": "Tau cross imagery emphasizes sacrifice."
+          },
+          "Death": {
+            "hebrew": "Nun",
+            "element": "Scorpio",
+            "notes": "Scythe and serpent depict transformative cycles."
+          },
+          "Art": {
+            "hebrew": "Samekh",
+            "element": "Sagittarius",
+            "notes": "Temperance renamed to stress alchemical recombination."
+          },
+          "The Devil": {
+            "hebrew": "Ayin",
+            "element": "Capricorn",
+            "notes": "Goat of Mendes merges with DNA symbolism."
+          },
+          "The Tower": {
+            "hebrew": "Peh",
+            "element": "Mars",
+            "notes": "Called War in some early manuscripts; emphasizes lightning-initiation."
+          },
+          "The Star": {
+            "hebrew": "Heh",
+            "element": "Aquarius",
+            "notes": "Letter swap relative to Golden Dawn placements."
+          },
+          "The Moon": {
+            "hebrew": "Qoph",
+            "element": "Pisces",
+            "notes": "Path of occult trial with scarab, jackal, and wolf."
+          },
+          "The Sun": {
+            "hebrew": "Resh",
+            "element": "Sun",
+            "notes": "Twins dance under solar disks and wall of roses."
+          },
+          "The Aeon": {
+            "hebrew": "Shin",
+            "element": "Fire",
+            "notes": "Judgement recast as new aeon proclamation."
+          },
+          "The Universe": {
+            "hebrew": "Tau",
+            "element": "Saturn",
+            "notes": "World renamed; shows goddess in cosmic oval."
+          }
+        }
+      },
+      "playing_card_reduction": {
+        "method": "Remap minor arcana to standard 52-card playing deck for cartomancy hybrids.",
+        "mapping": {
+          "wands": "clubs",
+          "cups": "hearts",
+          "swords": "spades",
+          "pentacles": "diamonds"
+        },
+        "court_alignment": {
+          "page": "jack",
+          "knight": "knight",
+          "queen": "queen",
+          "king": "king"
+        }
+      }
+    }
+  }
+}

--- a/entities/oracle/predictive_divination_extension/assets/tarot_rws.json
+++ b/entities/oracle/predictive_divination_extension/assets/tarot_rws.json
@@ -1,0 +1,2947 @@
+{
+  "rws_1909": {
+    "metadata": {
+      "deck": "Rider–Waite–Smith",
+      "year": 1909,
+      "designers": [
+        "A. E. Waite",
+        "Pamela Colman Smith"
+      ],
+      "sources": [
+        "Public domain descriptions synthesized from A. E. Waite's Pictorial Key to the Tarot",
+        "Meanings adapted from Mark McElroy's 'A Guide to Tarot Meanings' via dariusk/corpora dataset"
+      ],
+      "structure": {
+        "major_arcana": 22,
+        "minor_arcana": {
+          "total": 56,
+          "suits": [
+            "Wands",
+            "Cups",
+            "Swords",
+            "Pentacles"
+          ],
+          "court_cards": [
+            "Page",
+            "Knight",
+            "Queen",
+            "King"
+          ]
+        }
+      }
+    },
+    "major_arcana": [
+      {
+        "name": "The Fool",
+        "number": 0,
+        "keywords": [
+          "freedom",
+          "faith",
+          "inexperience",
+          "innocence"
+        ],
+        "fortune_telling": [
+          "Watch for new projects and new beginnings",
+          "Prepare to take something on faith",
+          "Something new comes your way; go for it"
+        ],
+        "meanings": {
+          "upright": [
+            "Freeing yourself from limitation",
+            "Expressing joy and youthful vigor",
+            "Being open-minded",
+            "Taking a leap of faith",
+            "Attuning yourself to your instincts",
+            "Being eager or curious",
+            "Exploring your potential",
+            "Embracing innovation and change"
+          ],
+          "reversed": [
+            "Being gullible and naive",
+            "Taking unnecessary risks",
+            "Failing to be serious when required",
+            "Being silly or distracted",
+            "Lacking experience",
+            "Failing to honor well-established traditions and limits",
+            "Behaving inappropriately"
+          ]
+        },
+        "correspondences": {
+          "element": "Air",
+          "astrology": "Uranus",
+          "hebrew_letter": "Aleph",
+          "path_on_tree_of_life": 11
+        }
+      },
+      {
+        "name": "The Magician",
+        "number": 1,
+        "keywords": [
+          "capability",
+          "empowerment",
+          "activity"
+        ],
+        "fortune_telling": [
+          "A powerful man may play a role in your day",
+          "Your current situation must be seen as one element of a much larger plan"
+        ],
+        "meanings": {
+          "upright": [
+            "Taking appropriate action",
+            "Receiving guidance from a higher power",
+            "Becoming a channel of divine will",
+            "Expressing masculine energy in appropriate and constructive ways",
+            "Being yourself in every way"
+          ],
+          "reversed": [
+            "Inflating your own ego",
+            "Abusing talents",
+            "Manipulating or deceiving others",
+            "Being too aggressive",
+            "Using cheap illusions to dazzle others",
+            "Refusing to invest the time and effort needed to master your craft",
+            "Taking shortcuts"
+          ]
+        },
+        "correspondences": {
+          "element": "Air",
+          "astrology": "Mercury",
+          "hebrew_letter": "Beth",
+          "path_on_tree_of_life": 12
+        }
+      },
+      {
+        "name": "The High Priestess",
+        "number": 2,
+        "keywords": [
+          "intuition",
+          "reflection",
+          "purity",
+          "initiation"
+        ],
+        "fortune_telling": [
+          "A mysterious woman arrives",
+          "A sexual secret may surface",
+          "Someone knows more than he or she will reveal"
+        ],
+        "meanings": {
+          "upright": [
+            "Listening to your feelings and intuitions",
+            "Exploring unconventional spirituality",
+            "Keeping secrets",
+            "Being receptive",
+            "Reflecting instead of acting",
+            "Observing others",
+            "Preserving purity"
+          ],
+          "reversed": [
+            "Being aloof",
+            "Obsessing on secrets and conspiracies",
+            "Rejecting guidance from spirit or intuition",
+            "Revealing all",
+            "Ignoring gut feelings",
+            "Refusing to become involved, even when involvement is appropriate"
+          ]
+        },
+        "correspondences": {
+          "element": "Water",
+          "astrology": "Moon",
+          "hebrew_letter": "Gimel",
+          "path_on_tree_of_life": 13
+        }
+      },
+      {
+        "name": "The Empress",
+        "number": 3,
+        "keywords": [
+          "fertility",
+          "productivity",
+          "ripeness",
+          "nurturing"
+        ],
+        "fortune_telling": [
+          "Pregnancy is in the cards",
+          "An opportunity to be involved in luxurious sexuality is coming",
+          "Beware a tendency toward addiction"
+        ],
+        "meanings": {
+          "upright": [
+            "Nurturing yourself and others",
+            "Bearing fruit",
+            "Celebrating your body",
+            "Bearing (literal or figurative) children",
+            "Reveling in luxury",
+            "Mothering those around you in positive ways",
+            "Enjoying your sexuality",
+            "Getting things done"
+          ],
+          "reversed": [
+            "Overindulging",
+            "Being greedy",
+            "Smothering someone with attention",
+            "Debilitating someone by being overprotective",
+            "Inhibiting productivity by obsessing on productivity",
+            "Being overcome by addictive behavior"
+          ]
+        },
+        "correspondences": {
+          "element": "Earth",
+          "astrology": "Venus",
+          "hebrew_letter": "Daleth",
+          "path_on_tree_of_life": 14
+        }
+      },
+      {
+        "name": "The Emperor",
+        "number": 4,
+        "keywords": [
+          "authority",
+          "regulation",
+          "direction",
+          "structure"
+        ],
+        "fortune_telling": [
+          "A father figure arrives",
+          "A new employer or authority figure will give you orders",
+          "Expect discipline or correction in the near future"
+        ],
+        "meanings": {
+          "upright": [
+            "Exercising authority",
+            "Defining limits",
+            "Directing the flow of work",
+            "Communicating clear guidelines",
+            "Being in control of yourself and others",
+            "Tempering aggressive masculinity with wisdom and experience"
+          ],
+          "reversed": [
+            "Micromanaging",
+            "Crushing the creativity of others with a rigid, iron-fisted approach",
+            "Insisting on getting your own way",
+            "Assuming a dictatorial mindset",
+            "Using overt force to achieve your goals and maintain order"
+          ]
+        },
+        "correspondences": {
+          "element": "Fire",
+          "astrology": "Aries",
+          "hebrew_letter": "Heh",
+          "path_on_tree_of_life": 15
+        }
+      },
+      {
+        "name": "The Hierophant",
+        "number": 5,
+        "keywords": [
+          "guidance",
+          "knowledge",
+          "revelation",
+          "belief"
+        ],
+        "fortune_telling": [
+          "Expect to be caught in a misdeed and punished accordingly",
+          "Pray for forgiveness and confess wrongdoings",
+          "A more experienced man, spiritual leader, or father figure will come into your life"
+        ],
+        "meanings": {
+          "upright": [
+            "Teaching or guiding others",
+            "Searching for the truth",
+            "Asking for guidance from a higher power",
+            "Acknowledging the wisdom and experience of others",
+            "Taking vows",
+            "Engaging in heartfelt rituals",
+            "Volunteering"
+          ],
+          "reversed": [
+            "Using experience as a means of manipulating or misguiding others",
+            "Being dogmatic",
+            "Favoring tradition over what is expedient or necessary",
+            "Going through the motions of empty rituals",
+            "Concealing wisdom",
+            "Restricting access to spiritual truths or the gods"
+          ]
+        },
+        "correspondences": {
+          "element": "Earth",
+          "astrology": "Taurus",
+          "hebrew_letter": "Vav",
+          "path_on_tree_of_life": 16
+        }
+      },
+      {
+        "name": "The Lovers",
+        "number": 6,
+        "keywords": [
+          "love",
+          "passion",
+          "unity",
+          "choice"
+        ],
+        "fortune_telling": [
+          "A new personal or professional relationship blossoms",
+          "Sexual opportunities abound",
+          "Unexpectedly, a friend becomes a lover"
+        ],
+        "meanings": {
+          "upright": [
+            "Being in love",
+            "Showing your love to others",
+            "Expressing passion or romantic feelings",
+            "Aligning yourself with groups or like-minded others",
+            "Bringing people together",
+            "Making well-informed decisions"
+          ],
+          "reversed": [
+            "Debilitating passion",
+            "Allowing an unhealthy desire for love to motivate destructive behavior",
+            "Disrupting unity",
+            "Working against the best interests of those who care about you",
+            "Ill-informed decisions"
+          ]
+        },
+        "correspondences": {
+          "element": "Air",
+          "astrology": "Gemini",
+          "hebrew_letter": "Zain",
+          "path_on_tree_of_life": 17
+        }
+      },
+      {
+        "name": "The Chariot",
+        "number": 7,
+        "keywords": [
+          "advancement",
+          "victory",
+          "triumph",
+          "success"
+        ],
+        "fortune_telling": [
+          "Victory is a certainty",
+          "Move ahead with all plans",
+          "Beware the jealousy of others"
+        ],
+        "meanings": {
+          "upright": [
+            "Breaking through barriers",
+            "Moving forward with confidence and authority",
+            "Reaching the pinnacle of success",
+            "Basking in the glory of achievement",
+            "Guiding an effort to total victory",
+            "Establishing yourself as a worthy leader"
+          ],
+          "reversed": [
+            "Resting on laurels",
+            "Riding roughshod over the feelings or expectations of others",
+            "Focusing more on past successes than future opportunities",
+            "Failing to rein in impulsive behavior"
+          ]
+        },
+        "correspondences": {
+          "element": "Water",
+          "astrology": "Cancer",
+          "hebrew_letter": "Cheth",
+          "path_on_tree_of_life": 18
+        }
+      },
+      {
+        "name": "Strength",
+        "number": 8,
+        "keywords": [
+          "discipline",
+          "boldness",
+          "self-discipline",
+          "power",
+          "vitality"
+        ],
+        "fortune_telling": [
+          "Your self-control will be tested",
+          "A woman will seek to change her partner or lover",
+          "You are a strong, capable person"
+        ],
+        "meanings": {
+          "upright": [
+            "Imposing restrictions on yourself for your own benefit",
+            "Bringing your passions under the control of reason",
+            "Resisting impulses that work against your best interests",
+            "Taking bold action"
+          ],
+          "reversed": [
+            "Indulging weakness, even when you know it will damage your health and happiness",
+            "Languishing in addiction",
+            "Allowing your instincts to tame and conquer you",
+            "Failing to take a stand when necessary"
+          ]
+        },
+        "correspondences": {
+          "element": "Fire",
+          "astrology": "Leo",
+          "hebrew_letter": "Teth",
+          "path_on_tree_of_life": 19
+        }
+      },
+      {
+        "name": "The Hermit",
+        "number": 9,
+        "keywords": [
+          "solitude",
+          "experience",
+          "stillness",
+          "withdrawal"
+        ],
+        "fortune_telling": [
+          "A period of loneliness begins",
+          "One partner in a relationship departs",
+          "A search for love or money proves fruitless"
+        ],
+        "meanings": {
+          "upright": [
+            "Becoming or seeking out a guru",
+            "Going on a retreat",
+            "Recharging spiritual or creative batteries",
+            "Lighting the way for those with less experience",
+            "Stepping back to gain perspective"
+          ],
+          "reversed": [
+            "Being a loner",
+            "Fearing contact with others",
+            "Becoming a know-it-all",
+            "Inflating claims of expertise",
+            "Hiding your skills and talents out of fear of unworthiness"
+          ]
+        },
+        "correspondences": {
+          "element": "Earth",
+          "astrology": "Virgo",
+          "hebrew_letter": "Yod",
+          "path_on_tree_of_life": 20
+        }
+      },
+      {
+        "name": "Wheel of Fortune",
+        "number": 10,
+        "keywords": [
+          "luck",
+          "randomness",
+          "cycles",
+          "karma",
+          "fate",
+          "revolution"
+        ],
+        "fortune_telling": [
+          "Some events are in the hands of heaven",
+          "You've lived through this before",
+          "What happened then?"
+        ],
+        "meanings": {
+          "upright": [
+            "Allowing events to unfold",
+            "Seeing the larger pattern in everyday events",
+            "Trusting your luck",
+            "Watching for cycles",
+            "Believing that \"what goes around, comes around\""
+          ],
+          "reversed": [
+            "Losing money gambling",
+            "Refusing to do your part to bring a plan to fruition",
+            "Taking a fatalistic approach to life",
+            "Fighting the natural course of events"
+          ]
+        },
+        "correspondences": {
+          "element": "Fire",
+          "astrology": "Jupiter",
+          "hebrew_letter": "Kaph",
+          "path_on_tree_of_life": 21
+        }
+      },
+      {
+        "name": "Justice",
+        "number": 11,
+        "keywords": [
+          "balance",
+          "law",
+          "fairness",
+          "objectivity"
+        ],
+        "fortune_telling": [
+          "A legal verdict will be rendered soon",
+          "Someone is making a decision",
+          "You need to get the facts"
+        ],
+        "meanings": {
+          "upright": [
+            "Making an objective decision",
+            "Weighing an issue carefully before taking action",
+            "Appropriately scaling your reaction to a situation",
+            "Getting all the facts",
+            "Considering evidence",
+            "Deliberating"
+          ],
+          "reversed": [
+            "Delivering harsh criticism",
+            "Obsessing on rules and regulations",
+            "Playing by the book even when it is destructive or counterproductive to do so",
+            "Confusing snap decisions with timely action",
+            "Playing favorites"
+          ]
+        },
+        "correspondences": {
+          "element": "Air",
+          "astrology": "Libra",
+          "hebrew_letter": "Lamed",
+          "path_on_tree_of_life": 22
+        }
+      },
+      {
+        "name": "The Hanged Man",
+        "number": 12,
+        "keywords": [
+          "enlightenment",
+          "sacrifice",
+          "perspective",
+          "suspension",
+          "reversals"
+        ],
+        "fortune_telling": [
+          "A traitor is revealed",
+          "One of your friends is working against you",
+          "Change your ways or suffer the consequences"
+        ],
+        "meanings": {
+          "upright": [
+            "Seeing growth opportunities in unpleasant events",
+            "Experiencing a dramatic change in personal perspective",
+            "Making the best of an unforeseen change in your life or work",
+            "Suspending disbelief",
+            "Making sacrifices"
+          ],
+          "reversed": [
+            "Being untrue to yourself and your values",
+            "Refusing to make sacrifices when appropriate",
+            "Refusing to adapt to new situations",
+            "Blaming others",
+            "Profiting at the expense of others"
+          ]
+        },
+        "correspondences": {
+          "element": "Water",
+          "astrology": "Neptune",
+          "hebrew_letter": "Mem",
+          "path_on_tree_of_life": 23
+        }
+      },
+      {
+        "name": "Death",
+        "number": 13,
+        "keywords": [
+          "ending",
+          "conclusion",
+          "transition",
+          "passage",
+          "departure"
+        ],
+        "fortune_telling": [
+          "A relationship or illness ends suddenly",
+          "Limit travel and risk-taking",
+          "General gloom and doom"
+        ],
+        "meanings": {
+          "upright": [
+            "Bringing an unpleasant phase of life to an end",
+            "Recognizing and celebrating the conclusion of something",
+            "Putting bad habits to rest",
+            "Becoming a new person",
+            "Leaving one person, place, or thing for another",
+            "Letting go"
+          ],
+          "reversed": [
+            "Obsessing on death and dying",
+            "Refusing to give up old habits or unhealthy relationships",
+            "Insisting that everything and everyone should stay the same forever",
+            "Failing to take good care of yourself"
+          ]
+        },
+        "correspondences": {
+          "element": "Water",
+          "astrology": "Scorpio",
+          "hebrew_letter": "Nun",
+          "path_on_tree_of_life": 24
+        }
+      },
+      {
+        "name": "Temperance",
+        "number": 14,
+        "keywords": [
+          "blending",
+          "synthesis",
+          "mediation",
+          "combination",
+          "harmony"
+        ],
+        "fortune_telling": [
+          "Someone's using drugs or alcohol to excess",
+          "It's time to get back on that diet"
+        ],
+        "meanings": {
+          "upright": [
+            "Bringing opposites together",
+            "Moderating your actions or emotions",
+            "Finding middle ground",
+            "Reaching compromises",
+            "Synthesizing solutions that please everyone involved",
+            "Using the old to make something new"
+          ],
+          "reversed": [
+            "Going to extremes",
+            "Disrupting group efforts",
+            "Ignoring healthy approaches to life",
+            "Becoming an addict",
+            "Practicing gluttony",
+            "Tearing something or someone apart",
+            "Breaking alliances"
+          ]
+        },
+        "correspondences": {
+          "element": "Fire",
+          "astrology": "Sagittarius",
+          "hebrew_letter": "Samekh",
+          "path_on_tree_of_life": 25
+        }
+      },
+      {
+        "name": "The Devil",
+        "number": 15,
+        "keywords": [
+          "shadow",
+          "materialism",
+          "bondage",
+          "delusion"
+        ],
+        "fortune_telling": [
+          "Adultery and unfaithfulness",
+          "A string of extremely bad luck is coming your way",
+          "Beware evil influences and wolves in sheep's clothing"
+        ],
+        "meanings": {
+          "upright": [
+            "Appreciating the luxuries that life has to offer",
+            "Being comfortable in your own skin",
+            "Enjoying your sexuality",
+            "Splurging on an expensive personal item",
+            "Embracing the fact that everyone has a darker side",
+            "Dealing with unhealthy impulses in healthy ways"
+          ],
+          "reversed": [
+            "Putting excessive emphasis on appearances",
+            "Always wanting more",
+            "Valuing possessions more than people or relationships",
+            "Allowing base instincts to govern your life",
+            "Being selfish",
+            "Attributing your own dark impulses to outside forces or other people"
+          ]
+        },
+        "correspondences": {
+          "element": "Earth",
+          "astrology": "Capricorn",
+          "hebrew_letter": "Ayin",
+          "path_on_tree_of_life": 26
+        }
+      },
+      {
+        "name": "The Tower",
+        "number": 16,
+        "keywords": [
+          "demolition",
+          "upheaval",
+          "deconstruction",
+          "disaster",
+          "destruction"
+        ],
+        "fortune_telling": [
+          "Impending disaster",
+          "Cancel plans and reverse decisions",
+          "Someone wants to take you down a notch or two",
+          "Don't hold back; say what you really mean"
+        ],
+        "meanings": {
+          "upright": [
+            "Breaking out of old, confining habits and mindsets",
+            "Clearing the way for new growth",
+            "Dispelling the influence of an inflated ego",
+            "Getting back to basics",
+            "Stripping away harmful illusions",
+            "Receiving sudden insight"
+          ],
+          "reversed": [
+            "Clinging to traditions that repress growth",
+            "Engaging in willful blindness",
+            "Rejecting evidence that change is needed",
+            "Ignoring guidance from a higher power",
+            "Maliciously engaging in destructive behavior"
+          ]
+        },
+        "correspondences": {
+          "element": "Fire",
+          "astrology": "Mars",
+          "hebrew_letter": "Peh",
+          "path_on_tree_of_life": 27
+        }
+      },
+      {
+        "name": "The Star",
+        "number": 17,
+        "keywords": [
+          "hope",
+          "optimism",
+          "openness",
+          "certainty",
+          "faith",
+          "longing",
+          "truth"
+        ],
+        "fortune_telling": [
+          "Get an astrology chart drawn up",
+          "Someone is a little too starstruck",
+          "What's happening now has long been fore-ordained"
+        ],
+        "meanings": {
+          "upright": [
+            "Hoping for the best",
+            "Believing good things happen to good people",
+            "Seeing events in the best possible light",
+            "Adopting a generous spirit",
+            "Seeking guidance from above",
+            "Embracing possibility over probability"
+          ],
+          "reversed": [
+            "Denying unpleasant truths",
+            "Denying personal accountability and saying, \"Things just happen!\"",
+            "Ignoring signs and omens",
+            "Preferring illusion to reality",
+            "Spreading pessimism and stinginess of spirit"
+          ]
+        },
+        "correspondences": {
+          "element": "Air",
+          "astrology": "Aquarius",
+          "hebrew_letter": "Tzaddi",
+          "path_on_tree_of_life": 28
+        }
+      },
+      {
+        "name": "The Moon",
+        "number": 18,
+        "keywords": [
+          "mystery",
+          "fantasy",
+          "imagination",
+          "dreams",
+          "uncertainty"
+        ],
+        "fortune_telling": [
+          "Watch for problems at the end of the month",
+          "Someone you know needs to howl at the moon more often",
+          "Someone is about to change his or her mind about an important decision"
+        ],
+        "meanings": {
+          "upright": [
+            "Enjoying healthy fantasies and daydreams",
+            "Using your imagination",
+            "Practicing magic or celebrating the magic of everyday life",
+            "Attuning yourself to the cycles of nature",
+            "Embracing the unknown"
+          ],
+          "reversed": [
+            "Becoming unable to separate fantasy from reality",
+            "Suffering from delusions",
+            "Losing your appreciation for the fantastic or magical",
+            "Adopting a ruthlessly logical mindset",
+            "Failing to appreciate life's mysteries"
+          ]
+        },
+        "correspondences": {
+          "element": "Water",
+          "astrology": "Pisces",
+          "hebrew_letter": "Qoph",
+          "path_on_tree_of_life": 29
+        }
+      },
+      {
+        "name": "The Sun",
+        "number": 19,
+        "keywords": [
+          "joy",
+          "brilliance",
+          "validation",
+          "attention",
+          "energy"
+        ],
+        "fortune_telling": [
+          "Everything's coming up roses (or sunflowers, whatever the case may be)",
+          "Whatever's on your mind, go for it because you can't lose today"
+        ],
+        "meanings": {
+          "upright": [
+            "Seeing things clearly",
+            "Experiencing intense joy",
+            "Celebrating your own successes",
+            "Knowing you're good at what you do",
+            "Gaining recognition for your personal genius"
+          ],
+          "reversed": [
+            "Being dazzled by your own accomplishments",
+            "Becoming absorbed in your own self-image",
+            "Feeling rushed and distracted",
+            "Exerting yourself to the point of exhaustion",
+            "Overstating your abilities or misrepresenting your achievements"
+          ]
+        },
+        "correspondences": {
+          "element": "Fire",
+          "astrology": "Sun",
+          "hebrew_letter": "Resh",
+          "path_on_tree_of_life": 30
+        }
+      },
+      {
+        "name": "Judgement",
+        "number": 20,
+        "keywords": [
+          "revival",
+          "renewal",
+          "resurrection",
+          "evaluation",
+          "invitation"
+        ],
+        "fortune_telling": [
+          "An old issue you thought was over will come up again today",
+          "Get ready for huge changes: break-ups, sudden calls from old friends, and unexpected setbacks",
+          "God's trying to get your attention"
+        ],
+        "meanings": {
+          "upright": [
+            "Receiving a wake-up call",
+            "Discovering a new purpose in life",
+            "Becoming totally and completely yourself",
+            "Receiving a well-deserved reward",
+            "Passing an evaluation or examination",
+            "Welcoming the start of a new phase of life"
+          ],
+          "reversed": [
+            "Being weighed in the balances and found wanting",
+            "Failing to measure up to a well-defined standard",
+            "Being caught goofing off or misbehaving",
+            "Failing to prepare for an examination you know is coming",
+            "Rejecting an opportunity to reinvent yourself"
+          ]
+        },
+        "correspondences": {
+          "element": "Fire",
+          "astrology": "Pluto",
+          "hebrew_letter": "Shin",
+          "path_on_tree_of_life": 31
+        }
+      },
+      {
+        "name": "The World",
+        "number": 21,
+        "keywords": [
+          "wholeness",
+          "integration",
+          "totality",
+          "completeness",
+          "fullness"
+        ],
+        "fortune_telling": [
+          "Winning the lottery",
+          "Getting your heart's desire",
+          "Having everything you ever imagined having"
+        ],
+        "meanings": {
+          "upright": [
+            "Having it all",
+            "Knowing and loving yourself as completely as possible",
+            "Seeing the interconnection of all things and people",
+            "Enhancing your perspective",
+            "Living life to its fullest",
+            "Understanding the meaning of life"
+          ],
+          "reversed": [
+            "Allowing greed and envy to prevent you from enjoying what you do possess",
+            "Failing to see the larger design in ordinary events",
+            "Believing that everything that exists can be touched, counted, or measured",
+            "Failing to see the divine reflected in those around you"
+          ]
+        },
+        "correspondences": {
+          "element": "Earth",
+          "astrology": "Saturn",
+          "hebrew_letter": "Tau",
+          "path_on_tree_of_life": 32
+        }
+      }
+    ],
+    "minor_arcana": {
+      "wands": {
+        "element": "Fire",
+        "season": "Spring",
+        "keywords": [
+          "drive",
+          "ambition",
+          "will"
+        ],
+        "cards": [
+          {
+            "name": "Ace of Wands",
+            "keywords": [
+              "desire",
+              "inspiration",
+              "vision",
+              "creation",
+              "invention"
+            ],
+            "fortune_telling": [
+              "Someone has the \"hots\" for you",
+              "A new job offer is coming your way",
+              "Walk softly, and carry a big stick"
+            ],
+            "meanings": {
+              "upright": [
+                "Being inspired",
+                "Identifying an important goal",
+                "Being given the opportunity to do whatever you want to do",
+                "Giving or receiving direction",
+                "Seeing a solution",
+                "Creating something new",
+                "Being aroused, sexually or creatively"
+              ],
+              "reversed": [
+                "Failing to take advantage of a great opportunity",
+                "Being ineffectual or lazy",
+                "Making an inadequate effort",
+                "Working toward a goal, but lacking the resources or initiative to achieve success",
+                "Setting inappropriate goals",
+                "Failing to take a stand"
+              ]
+            },
+            "rank": 1,
+            "numerology": "Beginnings, potential, initiation",
+            "correspondences": {
+              "concept": "Root of Fire"
+            }
+          },
+          {
+            "name": "Two of Wands",
+            "keywords": [
+              "conflict",
+              "decision",
+              "option",
+              "individuality"
+            ],
+            "fortune_telling": [
+              "Beware false friends",
+              "Don't be mealy-mouthed; say what you think and do what you want to do"
+            ],
+            "meanings": {
+              "upright": [
+                "Having a choice",
+                "Offering or being offered an option",
+                "Seeing the value of another person's approach",
+                "Understanding there's more than one way to \"skin a cat\"",
+                "Successfully doing more than one thing at a time",
+                "Being empowered to make a choice"
+              ],
+              "reversed": [
+                "Misrepresenting your intentions",
+                "Doing one thing while desiring another",
+                "Changing course mid-stream for no good reason",
+                "Refusing to change your goal even when pursuing it no longer makes sense",
+                "Disregarding the input of others"
+              ]
+            },
+            "rank": 2,
+            "numerology": "Duality, balance, partnership",
+            "correspondences": {
+              "golden_dawn_title": "Dominion",
+              "astrology": "Mars in Aries"
+            }
+          },
+          {
+            "name": "Three of Wands",
+            "keywords": [
+              "implementation",
+              "action",
+              "exploration"
+            ],
+            "fortune_telling": [
+              "You'll be planning a trip soon",
+              "Be on the lookout: your ship is coming in"
+            ],
+            "meanings": {
+              "upright": [
+                "Putting a plan into motion",
+                "Taking that critical first step",
+                "Making good things happen",
+                "Going beyond your limits",
+                "Blazing new trails",
+                "Hitting the ground running",
+                "Seeing your plans come to fruition"
+              ],
+              "reversed": [
+                "Procrastinating",
+                "Knowing what to do, but refusing to do it",
+                "Launching a project without a clear definition of who should do what",
+                "Rejecting an opportunity to try something new",
+                "Failing to finish what you start"
+              ]
+            },
+            "rank": 3,
+            "numerology": "Growth, synthesis, expression",
+            "correspondences": {
+              "golden_dawn_title": "Virtue",
+              "astrology": "Sun in Aries"
+            }
+          },
+          {
+            "name": "Four of Wands",
+            "keywords": [
+              "celebration",
+              "jubilation",
+              "community",
+              "teamwork",
+              "completion"
+            ],
+            "fortune_telling": [
+              "Someone is watching and evaluating your work",
+              "You may get a wedding invitation soon"
+            ],
+            "meanings": {
+              "upright": [
+                "Sharing in a great celebration",
+                "Sharing in a communal sense of achievement and success",
+                "Preparing for a party",
+                "Working together toward a common goal",
+                "Giving or winning awards"
+              ],
+              "reversed": [
+                "Keeping your nose to the grindstone",
+                "Recognizing good work by demanding more work",
+                "Failing to share in a group celebration",
+                "Allowing sour grapes to poison your moment in the sun",
+                "Refusing to do your part"
+              ]
+            },
+            "rank": 4,
+            "numerology": "Structure, stability, foundation",
+            "correspondences": {
+              "golden_dawn_title": "Completion",
+              "astrology": "Venus in Aries"
+            }
+          },
+          {
+            "name": "Five of Wands",
+            "keywords": [
+              "confrontation",
+              "disruption",
+              "distinction",
+              "objection",
+              "strife"
+            ],
+            "fortune_telling": [
+              "Prepare for a fight with your best friend",
+              "Remember: once you let words loose, you can't take them back"
+            ],
+            "meanings": {
+              "upright": [
+                "Calmly expressing a dissenting opinion",
+                "Allowing someone to use his or her own methods to get a job done",
+                "Opening the floor for discussion or debate",
+                "Comparing progress made so far to standards set earlier"
+              ],
+              "reversed": [
+                "Berating others for their ridiculous opinions",
+                "Picking fights",
+                "Offering destructive criticism",
+                "Baiting people with barbed remarks",
+                "Disrupting progress with an endless stream of pointless objections"
+              ]
+            },
+            "rank": 5,
+            "numerology": "Change, challenge, conflict",
+            "correspondences": {
+              "golden_dawn_title": "Strife",
+              "astrology": "Saturn in Leo"
+            }
+          },
+          {
+            "name": "Six of Wands",
+            "keywords": [
+              "victory",
+              "achievement",
+              "success",
+              "triumph"
+            ],
+            "fortune_telling": [
+              "Someone is planning a party for you, but not everyone feels so good about your recent success",
+              "Watch out for envious friends"
+            ],
+            "meanings": {
+              "upright": [
+                "Outperforming your peers",
+                "Winning a competition",
+                "Being recognized as a capable person",
+                "Having your \"moment in the spotlight\"",
+                "Being cheered on by the crowd",
+                "Getting an award",
+                "Earning the admiration of others",
+                "Telling someone, \"Good job!\""
+              ],
+              "reversed": [
+                "Being a bad winner",
+                "Allowing your achievements to inflate your ego",
+                "Looking down on people who seem less capable",
+                "Craving to be the center of attention",
+                "Giving or receiving insincere praise",
+                "Envying the achievements of others"
+              ]
+            },
+            "rank": 6,
+            "numerology": "Harmony, alignment, community",
+            "correspondences": {
+              "golden_dawn_title": "Victory",
+              "astrology": "Jupiter in Leo"
+            }
+          },
+          {
+            "name": "Seven of Wands",
+            "keywords": [
+              "bravery",
+              "resolve",
+              "determination"
+            ],
+            "fortune_telling": [
+              "Don't be surprised by a personal attack",
+              "Prepare to defend yourself or someone you love"
+            ],
+            "meanings": {
+              "upright": [
+                "Refusing to be silenced through fear or intimidation",
+                "Continuing a fight against all odds",
+                "Being fierce",
+                "Defending yourself against physical and emotional attacks",
+                "Refusing to put up with abuse",
+                "Clinging to your values despite all pressure to abandon them"
+              ],
+              "reversed": [
+                "Having a chip on your shoulder",
+                "Taking unnecessary risks as a means of proving your fearlessness",
+                "Looking for an opportunity to take offense",
+                "Responding to constructive criticism with defensiveness",
+                "Refusing to stand up for yourself and your beliefs"
+              ]
+            },
+            "rank": 7,
+            "numerology": "Assessment, faith, challenge",
+            "correspondences": {
+              "golden_dawn_title": "Valour",
+              "astrology": "Mars in Leo"
+            }
+          },
+          {
+            "name": "Eight of Wands",
+            "keywords": [
+              "speed",
+              "swiftness",
+              "responsiveness",
+              "change"
+            ],
+            "fortune_telling": [
+              "Watch for a surprising letter in the mail",
+              "Your whole world is about to be turned on its ear"
+            ],
+            "meanings": {
+              "upright": [
+                "Taking swift action",
+                "Moving forward with a plan as quickly as possible",
+                "Energizing yourself",
+                "Adapting to sudden changes",
+                "Taking setbacks in stride",
+                "Embracing the idea that nothing stays the same forever",
+                "Reacting quickly and appropriately to unforeseen problems"
+              ],
+              "reversed": [
+                "Giving in to panic",
+                "Running in circles and screaming",
+                "Insisting things must always stay the same",
+                "Stirring the pot just to see what will happen",
+                "Rushing others",
+                "Refusing to re-evaluate a schedule or program, even when it's clearly no longer appropriate"
+              ]
+            },
+            "rank": 8,
+            "numerology": "Movement, power, mastery",
+            "correspondences": {
+              "golden_dawn_title": "Swiftness",
+              "astrology": "Mercury in Sagittarius"
+            }
+          },
+          {
+            "name": "Nine of Wands",
+            "keywords": [
+              "toughness",
+              "persistence",
+              "stamina",
+              "loyalty",
+              "release"
+            ],
+            "fortune_telling": [
+              "Don't relax yet; there's more to come",
+              "The test you're facing now is happening for one reason: to show you who your real friends are"
+            ],
+            "meanings": {
+              "upright": [
+                "Sticking with it for the duration",
+                "Fulfilling your promises and obligations",
+                "Bearing up under incredible duress",
+                "Dragging yourself across the finish line",
+                "Picking yourself up by your own bootstraps",
+                "Refusing to quit",
+                "Going as far as you can go and being satisfied with your performance"
+              ],
+              "reversed": [
+                "Making yourself a martyr",
+                "Abandoning your post",
+                "Giving up at the first sign of opposition",
+                "Being prevented from fulfilling an obligation",
+                "Failing to be dependable",
+                "Refusing to let something go that needs to be released",
+                "Beating a dead horse"
+              ]
+            },
+            "rank": 9,
+            "numerology": "Culmination, attainment, reflection",
+            "correspondences": {
+              "golden_dawn_title": "Strength",
+              "astrology": "Moon in Sagittarius"
+            }
+          },
+          {
+            "name": "Ten of Wands",
+            "keywords": [
+              "exhaustion",
+              "resistance",
+              "burden",
+              "oppression"
+            ],
+            "fortune_telling": [
+              "You're worn out",
+              "Back off, take a time out, and let someone else handle things for a while"
+            ],
+            "meanings": {
+              "upright": [
+                "Holding your own in extreme circumstances",
+                "Helping others carry their burdens",
+                "Coming to the aid of the oppressed",
+                "Knowing and being honest about your own limits",
+                "Recognizing when you are not well-suited for a particular task"
+              ],
+              "reversed": [
+                "Taking on more work than you know you can handle",
+                "Refusing to say \"No\" when you're already overloaded",
+                "Making a habit of working overtime",
+                "Shielding others from facing the consequences of their own poor judgment",
+                "Over-extending yourself on a regular basis"
+              ]
+            },
+            "rank": 10,
+            "numerology": "Completion, transition, legacy",
+            "correspondences": {
+              "golden_dawn_title": "Oppression",
+              "astrology": "Saturn in Sagittarius"
+            }
+          },
+          {
+            "name": "Page of Wands",
+            "keywords": [
+              "enthusiasm",
+              "eagerness",
+              "confidence",
+              "validation",
+              "affirmation",
+              "messenger",
+              "student",
+              "beginnings"
+            ],
+            "fortune_telling": [
+              "This card represents a young man or woman with a fiery, enthusiastic demeanor, likely born a Cancer, Leo, or Virgo, who wants to start a new relationship with you"
+            ],
+            "meanings": {
+              "upright": [
+                "Leaping at a new opportunity",
+                "Being a cheerleader or ardent advocate for your cause",
+                "Being a True Believer",
+                "Taking first steps toward independence",
+                "Trusting in your own abilities",
+                "Asking for feedback"
+              ],
+              "reversed": [
+                "Basing your entire self-image on what others think",
+                "Seizing every new idea that comes your way without question",
+                "Habitually discounting input or feedback from others",
+                "Being so eager to \"do it yourself\" that you hinder your own progress"
+              ]
+            },
+            "rank": "Page",
+            "court_role": "Earth of Fire"
+          },
+          {
+            "name": "Knight of Wands",
+            "keywords": [
+              "boldness",
+              "bravado",
+              "passion",
+              "persuasion",
+              "advocacy",
+              "pursuit",
+              "movement",
+              "change"
+            ],
+            "fortune_telling": [
+              "This card represents a man with a bold, passionate personality, likely born between July 12th and August 11th, who wants to sweep you off your feet"
+            ],
+            "meanings": {
+              "upright": [
+                "Charging ahead",
+                "Making rapid progress",
+                "Refusing limits",
+                "Dazzling those around you with your wit and charm",
+                "Convincing others of your right to leadership",
+                "Convincing others to follow you",
+                "Being a catalyst for change"
+              ],
+              "reversed": [
+                "Blundering forward with inadequate skill or information",
+                "Running roughshod over the feelings of others",
+                "Using sex appeal to manipulate others",
+                "Forcing your leadership or ideology on others",
+                "Beginning many projects without finishing any"
+              ]
+            },
+            "rank": "Knight",
+            "court_role": "Air of Fire"
+          },
+          {
+            "name": "Queen of Wands",
+            "keywords": [
+              "attention",
+              "attraction",
+              "unification",
+              "collaboration",
+              "steward",
+              "nurture",
+              "intuition"
+            ],
+            "fortune_telling": [
+              "This card represents a woman with an attractive, appealing personality, likely born between March 11th and April 20th, who wants to charm you into doing things her way"
+            ],
+            "meanings": {
+              "upright": [
+                "Paying close attention",
+                "Helping others focus on the issue at hand",
+                "Getting everyone to work together",
+                "Identifying common ground",
+                "Bringing people together, despite their differences",
+                "Using reverse psychology"
+              ],
+              "reversed": [
+                "Being distracted, or using your charms or skills to distract others from the goal",
+                "Calling attention to yourself with negative or unhealthy behaviors",
+                "Disrupting group activities as a means of feeding your own ego"
+              ]
+            },
+            "rank": "Queen",
+            "court_role": "Water of Fire"
+          },
+          {
+            "name": "King of Wands",
+            "keywords": [
+              "creativity",
+              "ingenuity",
+              "achievement",
+              "direction",
+              "authority",
+              "mastery",
+              "vision"
+            ],
+            "fortune_telling": [
+              "This card represents an older man with a commanding, charismatic personality, likely born between November 13th and December 12th, who prefers to give directions and have them followed"
+            ],
+            "meanings": {
+              "upright": [
+                "Putting old things together in new and exciting ways",
+                "Coming up with unexpected solutions",
+                "Using your experience to solve puzzles and problems",
+                "Doing what you set out to do",
+                "Directing the efforts of others"
+              ],
+              "reversed": [
+                "Using your creativity to get out of honest work",
+                "Investing great energy in avoiding responsibility",
+                "Boasting about achievements without putting your expertise to practical use",
+                "Lording it over others"
+              ]
+            },
+            "rank": "King",
+            "court_role": "Fire of Fire"
+          }
+        ]
+      },
+      "cups": {
+        "element": "Water",
+        "season": "Summer",
+        "keywords": [
+          "emotion",
+          "relationships",
+          "intuition"
+        ],
+        "cards": [
+          {
+            "name": "Ace of Cups",
+            "keywords": [
+              "intuition",
+              "spirituality",
+              "affection",
+              "motivation"
+            ],
+            "fortune_telling": [
+              "Romance is in the cards",
+              "A new relationship or marriage is just around the corner",
+              "Prayers are answered"
+            ],
+            "meanings": {
+              "upright": [
+                "Trusting your feelings",
+                "Opening yourself to spirit",
+                "Accepting and returning affection",
+                "Getting in touch with what motivates you",
+                "Taking advantage of an opportunity to express love to others",
+                "Listening to the still, small voice"
+              ],
+              "reversed": [
+                "Hiding your feelings",
+                "Spurning an opportunity to love or be loved",
+                "Numbing yourself to spiritual yearnings",
+                "Rejecting the counsel of your heart",
+                "Becoming a puppet of your own emotions",
+                "Indulging in hysteria or obsession"
+              ]
+            },
+            "rank": 1,
+            "numerology": "Beginnings, potential, initiation",
+            "correspondences": {
+              "concept": "Root of Water"
+            }
+          },
+          {
+            "name": "Two of Cups",
+            "keywords": [
+              "union",
+              "attraction",
+              "combination",
+              "affection"
+            ],
+            "fortune_telling": [
+              "Someone has a secret crush on you",
+              "Relationships should be mutual; get rid of a leech"
+            ],
+            "meanings": {
+              "upright": [
+                "Being drawn to someone",
+                "Longing for someone or something",
+                "Acting on your desires",
+                "Discovering a feeling is mutual",
+                "Doing what makes you feel good",
+                "Merging",
+                "Healing broken ties",
+                "Admitting two people feel differently about each other and moving on"
+              ],
+              "reversed": [
+                "Burning bridges",
+                "Becoming caught up in unhealthy codependency",
+                "Shutting out anyone but your chosen few",
+                "Obsessing on someone who does not return your affections",
+                "Despairing over finding \"The One\"",
+                "Deceiving yourself about your true orientation"
+              ]
+            },
+            "rank": 2,
+            "numerology": "Duality, balance, partnership",
+            "correspondences": {
+              "golden_dawn_title": "Love",
+              "astrology": "Venus in Cancer"
+            }
+          },
+          {
+            "name": "Three of Cups",
+            "keywords": [
+              "celebration",
+              "expression",
+              "community",
+              "friendliness"
+            ],
+            "fortune_telling": [
+              "Unconventional romance is coming your way: a love affair with someone you've always dismissed"
+            ],
+            "meanings": {
+              "upright": [
+                "Celebrating your feelings or connections with others",
+                "Expressing joy through song, dance, or physical affection",
+                "Working together with others who share your feelings",
+                "Performing acts of service as a way of saying, \"I love you\"",
+                "Embracing unconventional romantic arrangements"
+              ],
+              "reversed": [
+                "Mistaking giddiness for true affection",
+                "Being dominated by manic emotions",
+                "Expecting everyone to always feel the same way you do",
+                "Demanding unreasonable support from friends or family",
+                "Partying to a dangerous or unhealthy extent"
+              ]
+            },
+            "rank": 3,
+            "numerology": "Growth, synthesis, expression",
+            "correspondences": {
+              "golden_dawn_title": "Abundance",
+              "astrology": "Mercury in Cancer"
+            }
+          },
+          {
+            "name": "Four of Cups",
+            "keywords": [
+              "boredom",
+              "listlessness",
+              "lethargy",
+              "stability",
+              "ingratitude"
+            ],
+            "fortune_telling": [
+              "A lover is getting restless",
+              "Find out what he or she needs, or new opportunities may lure your partner away"
+            ],
+            "meanings": {
+              "upright": [
+                "Maintaining your emotional stability",
+                "Refusing to give in to overwhelming emotions",
+                "Appreciating what you have and refusing to take it for granted",
+                "Seeing the value of long-term commitments"
+              ],
+              "reversed": [
+                "Being bored",
+                "Daydreaming at the expense of your work",
+                "Refusing to be engaged by opportunity",
+                "Taking people and relationships for granted",
+                "Ignoring romantic or spiritual opportunities",
+                "Spurning inspiration",
+                "Feeling everything should stay \"just like it is\""
+              ]
+            },
+            "rank": 4,
+            "numerology": "Structure, stability, foundation",
+            "correspondences": {
+              "golden_dawn_title": "Luxury",
+              "astrology": "Moon in Cancer"
+            }
+          },
+          {
+            "name": "Five of Cups",
+            "keywords": [
+              "loss",
+              "despair",
+              "re-evaluation",
+              "regret",
+              "uncertainty",
+              "repentance"
+            ],
+            "fortune_telling": [
+              "A breakup looms",
+              "Don't cry over spilt milk",
+              "Take your lumps and get back in the saddle"
+            ],
+            "meanings": {
+              "upright": [
+                "Acknowledging loss and moving on",
+                "Focusing on how the glass remains \"half-full\"",
+                "Finding the silver lining in a dark cloud",
+                "Recognizing that loss is a natural part of life",
+                "Embracing healthy grief",
+                "Learning lessons from harsh consequences"
+              ],
+              "reversed": [
+                "Wallowing in unhealthy grief or self-pity",
+                "Refusing to move on and let go",
+                "Clinging to the past",
+                "Obsessing on past lives and past loves",
+                "Failing to live in the present",
+                "Beating yourself up over past mistakes",
+                "Allowing fear of failure to limit your efforts"
+              ]
+            },
+            "rank": 5,
+            "numerology": "Change, challenge, conflict",
+            "correspondences": {
+              "golden_dawn_title": "Disappointment",
+              "astrology": "Mars in Scorpio"
+            }
+          },
+          {
+            "name": "Six of Cups",
+            "keywords": [
+              "charity",
+              "sharing",
+              "sacrifice",
+              "cooperation",
+              "fairness"
+            ],
+            "fortune_telling": [
+              "A stingy spirit is strangling your enjoyment of life",
+              "Loosen up and think of others for once, why don't you?"
+            ],
+            "meanings": {
+              "upright": [
+                "Donating your time and talents to others",
+                "Taking satisfaction in knowing how your efforts will aid others",
+                "Creating a \"win-win\" scenario",
+                "Giving even when you know repayment is not possible",
+                "Being motivated to do a good deed"
+              ],
+              "reversed": [
+                "Linking your sense of self-worth to the appraisals of others",
+                "Striving to appear more needy than you really are",
+                "Taking undeserved or unmerited charity",
+                "Bragging about your charitable efforts",
+                "Profiteering in times of distress",
+                "Refusing to share a burden"
+              ]
+            },
+            "rank": 6,
+            "numerology": "Harmony, alignment, community",
+            "correspondences": {
+              "golden_dawn_title": "Pleasure",
+              "astrology": "Sun in Scorpio"
+            }
+          },
+          {
+            "name": "Seven of Cups",
+            "keywords": [
+              "imagination",
+              "dreams",
+              "illusions",
+              "goals"
+            ],
+            "fortune_telling": [
+              "You're being fed a line",
+              "Rather than be dazzled by fancy words and promises, demand something real"
+            ],
+            "meanings": {
+              "upright": [
+                "Motivating yourself with images of future success",
+                "Using visualization to encourage progress",
+                "Taking an imaginative or creative approach to problem solving",
+                "Making dreams come true",
+                "Gleaning insight from personal visions"
+              ],
+              "reversed": [
+                "Obsessing on imaginary fears or uncertain consequences",
+                "Giving in to emotional or political terrorism",
+                "Spending more time dreaming than working",
+                "Failing to envision the possible repercussions of your choices",
+                "Being controlled by fear"
+              ]
+            },
+            "rank": 7,
+            "numerology": "Assessment, faith, challenge",
+            "correspondences": {
+              "golden_dawn_title": "Debauch",
+              "astrology": "Venus in Scorpio"
+            }
+          },
+          {
+            "name": "Eight of Cups",
+            "keywords": [
+              "longing",
+              "dissatisfaction",
+              "quest",
+              "departure",
+              "withdrawal"
+            ],
+            "fortune_telling": [
+              "Someone's \"stepping out\" on you, now or in the near future",
+              "Maybe it's time to quit talking about the problem and just move on"
+            ],
+            "meanings": {
+              "upright": [
+                "Wanting something better",
+                "Blazing your own trail",
+                "Realizing there must be more to life",
+                "Leaving an unhealthy situation behind",
+                "Starting your own business",
+                "Going on a retreat",
+                "Seeking the \"still, small voice\""
+              ],
+              "reversed": [
+                "Being implacable",
+                "Finding fault",
+                "Nitpicking",
+                "Refusing to settle down",
+                "Running away from problems or confrontations",
+                "Saying, \"It's my way or the highway!\"",
+                "Harping on past mistakes and disappointments",
+                "Threatening to quit as a strategy to get your way"
+              ]
+            },
+            "rank": 8,
+            "numerology": "Movement, power, mastery",
+            "correspondences": {
+              "golden_dawn_title": "Indolence",
+              "astrology": "Saturn in Pisces"
+            }
+          },
+          {
+            "name": "Nine of Cups",
+            "keywords": [
+              "satisfaction",
+              "sensuality",
+              "luxury",
+              "pleasure"
+            ],
+            "fortune_telling": [
+              "Whatever you want, you'll get it"
+            ],
+            "meanings": {
+              "upright": [
+                "Being delighted with your own achievements",
+                "Recognizing your own talents and abilities",
+                "Reveling in the good things life has to offer",
+                "Indulging yourself",
+                "Relaxing and unwinding",
+                "Having everything you need in order to feel complete"
+              ],
+              "reversed": [
+                "Being smug",
+                "Satisfying yourself at the expense of others",
+                "Being selfish",
+                "Over-indulging",
+                "Avoiding work that needs to be done",
+                "Claiming achievements or skills you do not possess",
+                "Never being satisfied, no matter how much you have"
+              ]
+            },
+            "rank": 9,
+            "numerology": "Culmination, attainment, reflection",
+            "correspondences": {
+              "golden_dawn_title": "Happiness",
+              "astrology": "Jupiter in Pisces"
+            }
+          },
+          {
+            "name": "Ten of Cups",
+            "keywords": [
+              "joy",
+              "fulfillment",
+              "overwhelming emotion",
+              "giddiness"
+            ],
+            "fortune_telling": [
+              "Marriage and family are in the cards",
+              "Expect a friendship to blossom into a romance"
+            ],
+            "meanings": {
+              "upright": [
+                "Having more than you ever dreamed",
+                "Being deeply thankful for all you've been given",
+                "Recognizing the Hand of God in the gifts the Universe brings your way",
+                "Experiencing transcendent joy",
+                "Achieving domestic bliss"
+              ],
+              "reversed": [
+                "Comparing your achievements or relationships to unrealistic fantasy standards",
+                "Experiencing emotions so intense they blunt your ability to cope with reality",
+                "Feeling overwhelmed",
+                "Envying the achievements and happiness of others"
+              ]
+            },
+            "rank": 10,
+            "numerology": "Completion, transition, legacy",
+            "correspondences": {
+              "golden_dawn_title": "Satiety",
+              "astrology": "Mars in Pisces"
+            }
+          },
+          {
+            "name": "Page of Cups",
+            "keywords": [
+              "enthusiasm",
+              "first impressions",
+              "romanticism",
+              "superficiality",
+              "messenger",
+              "student",
+              "beginnings"
+            ],
+            "fortune_telling": [
+              "This card represents a young man or woman with a watery, dreamy demeanor, likely born a Libra, Scorpio, or Sagittarius, who wants to start a new relationship with you"
+            ],
+            "meanings": {
+              "upright": [
+                "Showing your emotions freely",
+                "Throwing yourself into romance",
+                "Nursing a secret crush",
+                "Indulging in romantic fantasy",
+                "Starting a new relationship",
+                "Recalling your first love",
+                "Experiencing love for the first time",
+                "Converting to a new religion"
+              ],
+              "reversed": [
+                "Mistaking a crush for true love",
+                "Reading romantic intention into innocent action",
+                "Frantically trying to impress others",
+                "Indulging in overly-sweet sentimentality",
+                "Pretending to more romantic or spiritual experience than you possess"
+              ]
+            },
+            "rank": "Page",
+            "court_role": "Earth of Water"
+          },
+          {
+            "name": "Knight of Cups",
+            "keywords": [
+              "fervor",
+              "zeal",
+              "moodiness",
+              "illumination",
+              "pursuit",
+              "movement",
+              "change"
+            ],
+            "fortune_telling": [
+              "This card represents a man with an emotional, sensitive personality, likely born between October 13th and November 11th, who wants you to rally around his latest passionate cause"
+            ],
+            "meanings": {
+              "upright": [
+                "Being deeply committed to a cause",
+                "Giving in to strong emotions, from excitement to depression",
+                "Acting on intuition alone",
+                "Solving problems intuitively",
+                "Believing in and basing decisions on ideals instead of realities",
+                "Bringing intuition or passion to the table"
+              ],
+              "reversed": [
+                "Becoming a fanatic",
+                "Rejecting information that suggests your intuitions are misguided",
+                "Allowing your emotions to control you",
+                "Giving in to jealousy, confrontation, and peer pressure",
+                "Hiding or ignoring intuitive insights"
+              ]
+            },
+            "rank": "Knight",
+            "court_role": "Air of Water"
+          },
+          {
+            "name": "Queen of Cups",
+            "keywords": [
+              "insightfulness",
+              "spirituality",
+              "compassion",
+              "empathy",
+              "instinct",
+              "steward",
+              "nurture",
+              "intuition"
+            ],
+            "fortune_telling": [
+              "This card represents a woman with an emotional, deeply spiritual nature, likely born between June 11th and July 11th, who uses emotional and spiritual appeals to sway others to her point of view"
+            ],
+            "meanings": {
+              "upright": [
+                "Allowing yourself to be moved by the plight of others",
+                "Feeling strong emotions",
+                "Possessing unusual sympathy or empathy",
+                "Trusting your feelings to guide you",
+                "Calling on psychic abilities",
+                "Achieving unity with Spirit"
+              ],
+              "reversed": [
+                "Becoming so caught up in matters of Spirit, you become detached from the world",
+                "Allowing empathy to disable you (instead of inspire action)",
+                "Using psychic abilities to wield covert influence",
+                "Wallowing in emotionalism, sentiment, or self-pity"
+              ]
+            },
+            "rank": "Queen",
+            "court_role": "Water of Water"
+          },
+          {
+            "name": "King of Cups",
+            "keywords": [
+              "wisdom",
+              "diplomacy",
+              "restraint",
+              "composure",
+              "authority",
+              "mastery",
+              "vision"
+            ],
+            "fortune_telling": [
+              "This card represents an older man with a gentle, sensitive presence, likely born between February 9th and March 10th, who is known for his fairness and tolerance"
+            ],
+            "meanings": {
+              "upright": [
+                "Keeping a stiff upper lip",
+                "Being brave and clear in the face of adverse circumstances",
+                "Sharing experience as a way of comforting others",
+                "Making fair and empathetic decisions",
+                "Honoring the spirit, not just the letter, of the law"
+              ],
+              "reversed": [
+                "Allowing yourself to become rigid and unemotional",
+                "Making unfair decisions based on a hidden agenda",
+                "Making decisions without regard for their emotional impact on others",
+                "Abusing spiritual authority",
+                "Using emotional or spiritual leverage to exercise unhealthy control over others"
+              ]
+            },
+            "rank": "King",
+            "court_role": "Fire of Water"
+          }
+        ]
+      },
+      "swords": {
+        "element": "Air",
+        "season": "Autumn",
+        "keywords": [
+          "intellect",
+          "conflict",
+          "clarity"
+        ],
+        "cards": [
+          {
+            "name": "Ace of Swords",
+            "keywords": [
+              "logic",
+              "objectivity",
+              "intellect",
+              "choice"
+            ],
+            "fortune_telling": [
+              "The time to make a choice is now",
+              "Stop wavering and do what you know is best"
+            ],
+            "meanings": {
+              "upright": [
+                "Making objective decisions",
+                "Applying logic",
+                "Reasoning your way out of a difficult situation",
+                "Solving puzzles",
+                "Thinking things through",
+                "Emphasizing the facts",
+                "Clearing your mind",
+                "Seeking clarity"
+              ],
+              "reversed": [
+                "Applying ruthless or twisted logic",
+                "Gloating over your own superior intellect",
+                "Using quick thinking to deceive or confuse others",
+                "Confusing snap judgments with quick thinking",
+                "Making decisions without thinking through consequences"
+              ]
+            },
+            "rank": 1,
+            "numerology": "Beginnings, potential, initiation",
+            "correspondences": {
+              "concept": "Root of Air"
+            }
+          },
+          {
+            "name": "Two of Swords",
+            "keywords": [
+              "denial",
+              "debate",
+              "impasse",
+              "truce"
+            ],
+            "fortune_telling": [
+              "Sometimes, the only way to win is to refuse to fight",
+              "You're stuck for now; let time pass before taking action"
+            ],
+            "meanings": {
+              "upright": [
+                "Refusing to make a decision without getting the facts",
+                "Exploring both sides of an argument",
+                "Arguing passionately for what you believe in",
+                "Weighing the issues",
+                "Encouraging the open exchange of ideas",
+                "Discussing political or religious issues without getting \"hot under the collar\""
+              ],
+              "reversed": [
+                "Rejecting evidence that conflicts with dearly-held beliefs",
+                "Arguing with others just for the sake of doing so",
+                "Nit-picking",
+                "Putting off a decision because you're afraid to face the consequences",
+                "Preventing others from getting the information they need to make good decisions"
+              ]
+            },
+            "rank": 2,
+            "numerology": "Duality, balance, partnership",
+            "correspondences": {
+              "golden_dawn_title": "Peace",
+              "astrology": "Moon in Libra"
+            }
+          },
+          {
+            "name": "Three of Swords",
+            "keywords": [
+              "variance",
+              "difference",
+              "dissatisfaction",
+              "heartache",
+              "rejection"
+            ],
+            "fortune_telling": [
+              "Breakups and infidelity abound",
+              "What hurts now, though, will turn out to be good for you later on"
+            ],
+            "meanings": {
+              "upright": [
+                "Being brave enough to see things as they really are",
+                "Exercising your critical eye",
+                "Being your own best critic",
+                "Acknowledging that things don't always turn out as planned",
+                "Moving past heartbreak to embrace a painful truth"
+              ],
+              "reversed": [
+                "Wallowing in despair",
+                "Allowing yourself to be completely crushed by the thoughts, words, or deeds of another",
+                "Judging yourself too harshly",
+                "Holding yourself to an unrealistic standard of excellence",
+                "Wearing your heart on your sleeve while carrying a chip on your shoulder"
+              ]
+            },
+            "rank": 3,
+            "numerology": "Growth, synthesis, expression",
+            "correspondences": {
+              "golden_dawn_title": "Sorrow",
+              "astrology": "Saturn in Libra"
+            }
+          },
+          {
+            "name": "Four of Swords",
+            "keywords": [
+              "meditation",
+              "contemplation",
+              "perspective",
+              "mindset"
+            ],
+            "fortune_telling": [
+              "Don't make any decision now",
+              "Wait, and you'll be glad you did"
+            ],
+            "meanings": {
+              "upright": [
+                "Thinking over your plans before putting them into action",
+                "Pausing to meditate or clear your mind",
+                "Taking time to understand someone or something before criticizing it",
+                "Resting",
+                "Occupying your thoughts with a healthy distraction"
+              ],
+              "reversed": [
+                "Failing to think things through",
+                "Mistaking procrastination for thoughtfulness",
+                "Adopting a point of view and refusing to reconsider your conclusions, even when presented with refuting evidence",
+                "Allowing chaos and whimsy to dominate your thoughts"
+              ]
+            },
+            "rank": 4,
+            "numerology": "Structure, stability, foundation",
+            "correspondences": {
+              "golden_dawn_title": "Truce",
+              "astrology": "Jupiter in Libra"
+            }
+          },
+          {
+            "name": "Five of Swords",
+            "keywords": [
+              "selfishness",
+              "hostility",
+              "irrationality",
+              "self-preservation"
+            ],
+            "fortune_telling": [
+              "Someone is stealing from you, financially or romantically",
+              "Be wary of friends who talk behind your back"
+            ],
+            "meanings": {
+              "upright": [
+                "Acting in your own best interest",
+                "Choosing to stand up for yourself",
+                "Not backing down from disagreement and discord",
+                "Taking a stand",
+                "Refusing to go along with an unethical plan",
+                "Knowing when to bend the rules"
+              ],
+              "reversed": [
+                "Taking advantage of others",
+                "Intimidating others",
+                "Acting in an unethical manner",
+                "Picking fights",
+                "Using words to goad others into violence and irrationality",
+                "Ignoring rules you've agreed to abide by",
+                "Looking out for yourself while allowing harm to come to others",
+                "Gloating over victory"
+              ]
+            },
+            "rank": 5,
+            "numerology": "Change, challenge, conflict",
+            "correspondences": {
+              "golden_dawn_title": "Defeat",
+              "astrology": "Venus in Aquarius"
+            }
+          },
+          {
+            "name": "Six of Swords",
+            "keywords": [
+              "adaptation",
+              "adjustments",
+              "science",
+              "travel"
+            ],
+            "fortune_telling": [
+              "You'll soon go on a long journey over water",
+              "Actions have unexpected consequences, so be prepared"
+            ],
+            "meanings": {
+              "upright": [
+                "Making the best of a bad situation",
+                "Recovering from defeat",
+                "Resetting expectations",
+                "Making allowances for unexpected circumstances",
+                "Helping others who find themselves in dire circumstances",
+                "Changing the way you see the world",
+                "Broadening your perspective through study or travel"
+              ],
+              "reversed": [
+                "Refusing to accept that things have changed",
+                "Playing the victim",
+                "Rejecting the idea that your actions have consequences",
+                "Applying scientific criteria to matters of faith, or confusing faith with science",
+                "Believing the whole world should be like your small corner of it"
+              ]
+            },
+            "rank": 6,
+            "numerology": "Harmony, alignment, community",
+            "correspondences": {
+              "golden_dawn_title": "Science",
+              "astrology": "Mercury in Aquarius"
+            }
+          },
+          {
+            "name": "Seven of Swords",
+            "keywords": [
+              "dishonesty",
+              "presumption",
+              "sneakiness",
+              "assumptions"
+            ],
+            "fortune_telling": [
+              "Don't assume people around you are worthy of your trust",
+              "Ask for an accounting of where people have been, and what they've been doing"
+            ],
+            "meanings": {
+              "upright": [
+                "Refusing to do something dishonest, even when there's no chance of ever being caught",
+                "Handling a difficult situation with finesse",
+                "Pointing out assumptions",
+                "Acting ethically in public and in private",
+                "Living a life that is beyond reproach"
+              ],
+              "reversed": [
+                "Stealing or lying",
+                "Doing whatever you can get away with, simply because you can",
+                "Looking for a way around consequences",
+                "Justifying wicked behavior by focusing on the wickedness of others",
+                "Failing to examine your own motives and prejudices"
+              ]
+            },
+            "rank": 7,
+            "numerology": "Assessment, faith, challenge",
+            "correspondences": {
+              "golden_dawn_title": "Futility",
+              "astrology": "Moon in Aquarius"
+            }
+          },
+          {
+            "name": "Eight of Swords",
+            "keywords": [
+              "restriction",
+              "limitation",
+              "confinement",
+              "helplessness"
+            ],
+            "fortune_telling": [
+              "Get over playing the victim",
+              "Once you realize you are your own biggest obstacle, nothing can hold you back"
+            ],
+            "meanings": {
+              "upright": [
+                "Honoring limits",
+                "Respecting the rules",
+                "Deciding to go on a diet for your health's sake",
+                "Recognizing you cannot always be in control",
+                "Identifying obstacles to further progress",
+                "Refusing to think about unhealthy or unethical options",
+                "Asking for assistance"
+              ],
+              "reversed": [
+                "Feeling trapped",
+                "Being lost in a maze of rules and regulations",
+                "Giving in to despair",
+                "Playing the victim",
+                "Allowing others to dictate what you can and cannot do",
+                "Being rendered helpless",
+                "Having very few options",
+                "Failing to look for a way out"
+              ]
+            },
+            "rank": 8,
+            "numerology": "Movement, power, mastery",
+            "correspondences": {
+              "golden_dawn_title": "Interference",
+              "astrology": "Jupiter in Gemini"
+            }
+          },
+          {
+            "name": "Nine of Swords",
+            "keywords": [
+              "remorse",
+              "worry",
+              "distraught",
+              "conclusion"
+            ],
+            "fortune_telling": [
+              "If you take the action you're considering now, you'll be sorry in the future"
+            ],
+            "meanings": {
+              "upright": [
+                "Refusing to worry about what you cannot control",
+                "Rejecting anxiety",
+                "Judging your own performance with kindness and gentleness",
+                "Using meditation to quiet a troubled mind",
+                "Confronting nightmares and fears",
+                "Drawing a conclusion and putting an issue out of your mind"
+              ],
+              "reversed": [
+                "Torturing yourself with regrets",
+                "Second-guessing your every move",
+                "Beating yourself up for your mistakes",
+                "Depression",
+                "Obsessing on errors and overlooked details",
+                "Refusing to handle stress in healthy ways",
+                "Ruining your ability to appreciate the present by dwelling on the past",
+                "Debating irreversible decisions"
+              ]
+            },
+            "rank": 9,
+            "numerology": "Culmination, attainment, reflection",
+            "correspondences": {
+              "golden_dawn_title": "Cruelty",
+              "astrology": "Mars in Gemini"
+            }
+          },
+          {
+            "name": "Ten of Swords",
+            "keywords": [
+              "exhaustion",
+              "ruin",
+              "disaster",
+              "stamina",
+              "obsession"
+            ],
+            "fortune_telling": [
+              "Disaster",
+              "Put off plans and do not take action until omens are better"
+            ],
+            "meanings": {
+              "upright": [
+                "Seeing the signs that you've reached your limits",
+                "Paying attention to what your body is trying to tell you",
+                "Giving in to the need for rest and renewal",
+                "Acknowledging that you've hit bottom",
+                "Committing to a turnaround",
+                "Knowing the worst is over"
+              ],
+              "reversed": [
+                "Accepting defeat prematurely",
+                "Driving yourself to total exhaustion, especially mentally",
+                "Experiencing a mental breakdown",
+                "Obsessing on a problem to the breaking point",
+                "Giving up",
+                "Refusing to move from thought to action",
+                "Deeply unhealthy thoughts"
+              ]
+            },
+            "rank": 10,
+            "numerology": "Completion, transition, legacy",
+            "correspondences": {
+              "golden_dawn_title": "Ruin",
+              "astrology": "Sun in Gemini"
+            }
+          },
+          {
+            "name": "Page of Swords",
+            "keywords": [
+              "student",
+              "apprentice",
+              "scholarship",
+              "information",
+              "messenger",
+              "beginnings"
+            ],
+            "fortune_telling": [
+              "This card represents a young man or woman with an airy, intellectual demeanor, likely born a Capricorn, Aquarius, or Pisces, who wants to learn something new from you or have a discussion with you"
+            ],
+            "meanings": {
+              "upright": [
+                "Pursuing a course of study",
+                "Asking good questions",
+                "Investing time in study and practice",
+                "Doing research",
+                "Making a habit of learning new things",
+                "Starting an investigation",
+                "Outlining what you need to know",
+                "Finding a mentor or teacher"
+              ],
+              "reversed": [
+                "Pretending to knowledge or sophistication you do not possess",
+                "Cheating on an exam",
+                "Feigning interest as a way of gaining favor",
+                "Considering only the evidence that supports conclusions you've already drawn",
+                "Rejecting the wise counsel of experienced teachers"
+              ]
+            },
+            "rank": "Page",
+            "court_role": "Earth of Air"
+          },
+          {
+            "name": "Knight of Swords",
+            "keywords": [
+              "bluntness",
+              "intelligence",
+              "incisiveness",
+              "investigation",
+              "pursuit",
+              "movement",
+              "change"
+            ],
+            "fortune_telling": [
+              "A blunder leads someone to say something he or she regrets",
+              "If this was you, be prepared to apologize and move on"
+            ],
+            "meanings": {
+              "upright": [
+                "Speaking your mind",
+                "Making your opinions known",
+                "Offering constructive criticism",
+                "Sharing your knowledge",
+                "Making insightful observations",
+                "Pinpointing the problem",
+                "Clarifying what others have said",
+                "Giving clear direction to others",
+                "Uncovering the truth"
+              ],
+              "reversed": [
+                "Stating your opinions as fact",
+                "Picking fights",
+                "Starting arguments",
+                "Using clever insults to undermine the confidence of others",
+                "Tossing reason out the window",
+                "Speaking without taking the feelings of others into account",
+                "Going on a witch hunt",
+                "Distorting evidence"
+              ]
+            },
+            "rank": "Knight",
+            "court_role": "Air of Air"
+          },
+          {
+            "name": "Queen of Swords",
+            "keywords": [
+              "grace",
+              "skill",
+              "wit",
+              "charm",
+              "aptitude",
+              "steward",
+              "nurture",
+              "intuition"
+            ],
+            "fortune_telling": [
+              "This card represents a woman with an artistic, intellectual nature, likely born between September 12th and October 12th, who uses clever, positive communication to sway others to her point of view"
+            ],
+            "meanings": {
+              "upright": [
+                "Exercising tact or using diplomacy",
+                "Defusing a tense situation",
+                "Knowing what to say and how to say it",
+                "Making others feel comfortable and confident",
+                "Bringing out the best in everyone",
+                "Having a way with words",
+                "Telling jokes",
+                "Possessing a knack for music, math, art, or science"
+              ],
+              "reversed": [
+                "Knowing exactly what to say to destroy another person",
+                "Withholding critical information",
+                "Using a barbed tongue to upset others",
+                "Employing sarcasm",
+                "Mimicking others unkindly",
+                "Making light of the less fortunate",
+                "Being disrespectful",
+                "Failing to use the talent you've been given"
+              ]
+            },
+            "rank": "Queen",
+            "court_role": "Water of Air"
+          },
+          {
+            "name": "King of Swords",
+            "keywords": [
+              "genius",
+              "expertise",
+              "decision",
+              "verdict",
+              "authority",
+              "mastery",
+              "vision"
+            ],
+            "fortune_telling": [
+              "This card represents an older man with an insightful, deliberate spirit, likely born between May 11th and June 10th, who is known for his integrity and sharp decision-making ability"
+            ],
+            "meanings": {
+              "upright": [
+                "Expressing yourself with firmness and authority",
+                "Rendering a final decision",
+                "Consulting an expert",
+                "Calling in advisors and consultants",
+                "Coming to a final conclusion",
+                "Reaching a beneficial agreement based on sound information"
+              ],
+              "reversed": [
+                "Insisting on having the last word",
+                "Flaunting your intellectual capability",
+                "Talking \"over the heads\" of others",
+                "Waffling on an important decision",
+                "Constantly changing your mind",
+                "Refusing to make choices that are in your own best interest",
+                "Wishing in vain you could take back what's been said"
+              ]
+            },
+            "rank": "King",
+            "court_role": "Fire of Air"
+          }
+        ]
+      },
+      "pentacles": {
+        "element": "Earth",
+        "season": "Winter",
+        "keywords": [
+          "material",
+          "work",
+          "stability"
+        ],
+        "cards": [
+          {
+            "name": "Ace of Coins",
+            "keywords": [
+              "health",
+              "wealth",
+              "practicality",
+              "receiving"
+            ],
+            "fortune_telling": [
+              "Your health will improve",
+              "The check you're looking for really is in the mail"
+            ],
+            "meanings": {
+              "upright": [
+                "Outlining a plan for achieving prosperity",
+                "Becoming aware of opportunities to improve income or health",
+                "Realizing you have everything you need",
+                "Appreciating everything the Universe has given you",
+                "Receiving the perfect gift at the perfect time"
+              ],
+              "reversed": [
+                "Indulging in relentless consumerism",
+                "Wanting more, no matter how much you have",
+                "Obsessing on your account balance",
+                "Suffering from hypochondria",
+                "Consuming blessings without expressing gratitude",
+                "Taking what you want without concern for the needs of others"
+              ]
+            },
+            "rank": 1,
+            "numerology": "Beginnings, potential, initiation",
+            "correspondences": {
+              "concept": "Root of Earth"
+            }
+          },
+          {
+            "name": "Two of Coins",
+            "keywords": [
+              "evaluation",
+              "decision",
+              "budgeting",
+              "diagnosis"
+            ],
+            "fortune_telling": [
+              "It's time to balance the budget",
+              "Avoid the temptation to spend critical funds on frivolous goods"
+            ],
+            "meanings": {
+              "upright": [
+                "Weighing options",
+                "Comparing prices",
+                "Determining the value of one option over another",
+                "Juggling resources to make ends meet",
+                "Making difficult choices based on what's best for your body or your bankbook",
+                "Looking at the bottom line",
+                "Asking for a second opinion on health issues"
+              ],
+              "reversed": [
+                "Engaging in endless price comparison",
+                "Putting off a buying decision for fear of finding a slightly better value later on",
+                "Buying something without regard for value",
+                "Breaking your budget with unnecessary expenses",
+                "Engaging in behavior with no regard for how your body or bankbook will be impacted"
+              ]
+            },
+            "rank": 2,
+            "numerology": "Duality, balance, partnership"
+          },
+          {
+            "name": "Three of Coins",
+            "keywords": [
+              "expression",
+              "production",
+              "work",
+              "contribution"
+            ],
+            "fortune_telling": [
+              "A high-dollar contract is in your future",
+              "If you work hard, you'll succeed"
+            ],
+            "meanings": {
+              "upright": [
+                "Finishing a project",
+                "Setting and meeting standards",
+                "Performing according to specifications",
+                "Making something others value",
+                "Creating something new",
+                "Doing your part in a group project",
+                "Delivering exactly what others have asked for"
+              ],
+              "reversed": [
+                "Pandering to the tastes of others",
+                "Failing to deliver what you've promised",
+                "Not delivering your best work unless closely supervised",
+                "Ignoring or breaking agreements with those who have invested in you",
+                "Refusing to do your part",
+                "Failing to abide by a clearly-outlined agreement with yourself or others"
+              ]
+            },
+            "rank": 3,
+            "numerology": "Growth, synthesis, expression"
+          },
+          {
+            "name": "Four of Coins",
+            "keywords": [
+              "protection",
+              "conservation",
+              "preservation",
+              "safety"
+            ],
+            "fortune_telling": [
+              "A rainy day is coming—it's time to save"
+            ],
+            "meanings": {
+              "upright": [
+                "Saving for a rainy day",
+                "Fasting as part of a spiritual practice",
+                "Dieting in an effort to improve your body",
+                "Abstaining from sex as a way of honoring a spiritual tradition or personal promise",
+                "Being financially conservative",
+                "Establishing a trust fund",
+                "Opening a savings account"
+              ],
+              "reversed": [
+                "Being stingy",
+                "Refusing to spend money that needs to be spent",
+                "Withholding sex from your partner",
+                "Taking care of your own needs exclusively, without regard for the needs of others",
+                "Spending a dollar to save a penny",
+                "Failing to be a good manager of the blessings you've been given"
+              ]
+            },
+            "rank": 4,
+            "numerology": "Structure, stability, foundation"
+          },
+          {
+            "name": "Five of Coins",
+            "keywords": [
+              "poverty",
+              "destitution",
+              "need",
+              "crisis"
+            ],
+            "fortune_telling": [
+              "Finances are getting tighter",
+              "Prepare for a setback"
+            ],
+            "meanings": {
+              "upright": [
+                "Recognizing your needs and taking action to fulfill them",
+                "Doing as much as you can do with what little you have",
+                "Admitting you need help",
+                "Embracing the aid that comes your way",
+                "Focusing on what you have versus what you don't",
+                "Looking for the light at the end of the tunnel"
+              ],
+              "reversed": [
+                "Exaggerating your financial or physical needs",
+                "Adopting a poverty mentality",
+                "Refusing to support yourself",
+                "Refusing offers of support",
+                "Playing the martyr",
+                "Turning down opportunities to improve your health or finances",
+                "Wallowing in misery"
+              ]
+            },
+            "rank": 5,
+            "numerology": "Change, challenge, conflict"
+          },
+          {
+            "name": "Six of Coins",
+            "keywords": [
+              "charity",
+              "fairness",
+              "cooperation",
+              "sharing"
+            ],
+            "fortune_telling": [
+              "When you need help, ask for it",
+              "Remember, though: what you receive may be limited by what you've given to others in the past"
+            ],
+            "meanings": {
+              "upright": [
+                "Giving time, money, or effort to a charity",
+                "Taking part in a group effort",
+                "Lending your resources to others without expecting anything in return",
+                "Making sure everyone is treated equally",
+                "Working together toward a common goal",
+                "Redistributing wealth, time, or attention",
+                "Tithing",
+                "Sharing credit for your success"
+              ],
+              "reversed": [
+                "Making a loan as a means of gaining control over someone",
+                "Using charitable acts to draw attention to yourself",
+                "Dividing work or resources unfairly",
+                "Failing to do your part in a group effort",
+                "Ignoring obligations and commitments"
+              ]
+            },
+            "rank": 6,
+            "numerology": "Harmony, alignment, community"
+          },
+          {
+            "name": "Seven of Coins",
+            "keywords": [
+              "assessment",
+              "evaluation",
+              "re-evaluation",
+              "reflection"
+            ],
+            "fortune_telling": [
+              "Things won't work out as expected",
+              "Pick up the pieces and prepare to move on"
+            ],
+            "meanings": {
+              "upright": [
+                "Measuring progress toward your goal",
+                "Looking at results with an eye toward improving performance",
+                "Asking, \"How happy am I?\"",
+                "Coming up with ideas for improving your health or prosperity",
+                "Deciding it's time for a change",
+                "Expressing an honest opinion"
+              ],
+              "reversed": [
+                "Becoming distracted by melancholy thoughts",
+                "Longing for \"the good old days\"",
+                "Beating yourself up over lost opportunities",
+                "Judging your own work harshly",
+                "Holding others to inappropriate standards",
+                "Refusing to take part in a project, then whining about the quality of the outcome"
+              ]
+            },
+            "rank": 7,
+            "numerology": "Assessment, faith, challenge"
+          },
+          {
+            "name": "Eight of Coins",
+            "keywords": [
+              "effort",
+              "work diligence",
+              "skill"
+            ],
+            "fortune_telling": [
+              "Stop over-analyzing, researching, and outlining",
+              "Buckle down and get the work done"
+            ],
+            "meanings": {
+              "upright": [
+                "Doing your best",
+                "Bringing enthusiasm and zeal to your work",
+                "Making an effort to be the best you can be",
+                "Finding the work that is right for you",
+                "Taking care of the small details",
+                "Becoming a finely skilled craftsperson",
+                "Building something with your hands",
+                "Making a handmade gift"
+              ],
+              "reversed": [
+                "Working yourself to death",
+                "Doing a half-hearted or sloppy job",
+                "Continuing in a job you hate",
+                "Buying thoughtless gifts",
+                "Producing work with shoddy craftsmanship",
+                "Rushing through your work",
+                "Rejecting opportunities to learn more about your craft"
+              ]
+            },
+            "rank": 8,
+            "numerology": "Movement, power, mastery"
+          },
+          {
+            "name": "Nine of Coins",
+            "keywords": [
+              "training",
+              "discipline",
+              "confidence",
+              "enough"
+            ],
+            "fortune_telling": [
+              "Until you appreciate what you have, you won't have any luck getting more"
+            ],
+            "meanings": {
+              "upright": [
+                "Investing time in learning or teaching a difficult task",
+                "Restraining yourself from physical or financial extremes",
+                "Making sacrifices as a way of achieving larger goals",
+                "Breaking a complex task down into simple steps",
+                "Wanting what you have",
+                "Knowing the difference between needs and wants"
+              ],
+              "reversed": [
+                "Being assigned to a task without being trained to perform it",
+                "Pursuing a position for which you are not qualified",
+                "Disregarding requirements",
+                "Refusing to dedicate adequate time or attention when learning about something or someone new",
+                "Always craving more"
+              ]
+            },
+            "rank": 9,
+            "numerology": "Culmination, attainment, reflection"
+          },
+          {
+            "name": "Ten of Coins",
+            "keywords": [
+              "wealth",
+              "abundance",
+              "acquisition",
+              "greed"
+            ],
+            "fortune_telling": [
+              "Big money is in the near future",
+              "Expect a powerful blessing to come your way"
+            ],
+            "meanings": {
+              "upright": [
+                "Celebrating your physical and financial blessings",
+                "Realizing how lucky or how blessed you are",
+                "Being satisfied with your physical and financial achievements",
+                "Taking best advantage of \"times of plenty\"",
+                "Enjoying a feast",
+                "Showering friends or family with gifts"
+              ],
+              "reversed": [
+                "Spending all of your money on extravagant gifts and possessions",
+                "Trying too hard to impress others with your wealth or physique",
+                "Giving an inappropriately expensive gift as a means of currying favor",
+                "Obsessing on matters of weight, health, or finance",
+                "Always asking, \"What's in it for me?\""
+              ]
+            },
+            "rank": 10,
+            "numerology": "Completion, transition, legacy"
+          },
+          {
+            "name": "Page of Coins",
+            "keywords": [
+              "practicality",
+              "prosperity",
+              "learning",
+              "growth",
+              "adolescence",
+              "messenger",
+              "student",
+              "beginnings"
+            ],
+            "fortune_telling": [
+              "This card represents a young man or woman with an earthy, practical demeanor, likely born an Aries, Taurus, or Gemini, who playfully encourages you to take financial or sexual risks"
+            ],
+            "meanings": {
+              "upright": [
+                "Learning the value of a dollar",
+                "Starting a savings plan",
+                "Taking the first steps toward getting out of debt",
+                "Learning new physical tasks",
+                "Discovering your sexuality",
+                "Launching a diet, a weight-lifting program, or a health-related effort",
+                "Learning by doing"
+              ],
+              "reversed": [
+                "Trying to appear healthier or wealthier than you really are",
+                "Spending money carelessly",
+                "Living strictly for today, with no thought of tomorrow",
+                "Possessing immature attitudes toward sex and sexuality",
+                "Using wealth or beauty as an excuse for not having to learn and grow"
+              ]
+            },
+            "rank": "Page",
+            "court_role": "Earth of Earth"
+          },
+          {
+            "name": "Knight of Coins",
+            "keywords": [
+              "caution",
+              "focus",
+              "realism",
+              "invention",
+              "pursuit",
+              "movement",
+              "change"
+            ],
+            "fortune_telling": [
+              "A stingy person may chide you for spending money",
+              "Be prepared to defend an economic or sexual decision"
+            ],
+            "meanings": {
+              "upright": [
+                "Spending money wisely",
+                "Saving for a rainy day",
+                "Paying close attention to physical or financial details",
+                "Knowing where every dollar goes",
+                "Having safe sex",
+                "Preferring facts to \"good feelings\"",
+                "Finding creative ways to \"make do\" with resources on hand",
+                "Completing a new invention"
+              ],
+              "reversed": [
+                "Throwing caution to the four winds",
+                "Spending without regard for consequence",
+                "Spending on luxury when necessities are lacking",
+                "Escaping stress by spending money",
+                "Obsessing on tiny physical or financial details",
+                "Perpetually chasing after some new bauble",
+                "Copying another's work and claiming it as your own"
+              ]
+            },
+            "rank": "Knight",
+            "court_role": "Air of Earth"
+          },
+          {
+            "name": "Queen of Coins",
+            "keywords": [
+              "luxury",
+              "comfort",
+              "resourcefulness",
+              "generosity",
+              "prosperity",
+              "steward",
+              "nurture",
+              "intuition"
+            ],
+            "fortune_telling": [
+              "This card represents a woman with an expansive, sensual nature, likely born between December 13th and 31st, who uses sensual appeal and the promise of reward to sway others to her point of view"
+            ],
+            "meanings": {
+              "upright": [
+                "Appreciating fine food, fine wine, beautiful art, beautiful bodies, or any of the better things in life",
+                "Reveling in healthy sexuality",
+                "Treating yourself",
+                "Splurging on the occasional \"nice to have\" item",
+                "Rewarding someone with compensation above and beyond expectations",
+                "Having it all"
+              ],
+              "reversed": [
+                "Indulging in gluttony or greediness",
+                "Becoming insatiable",
+                "Blunting the impact of treats by indulging in them too often",
+                "Providing physical comfort without providing for emotional needs",
+                "Allowing a feeling of entitlement to distort your gratitude for what you're given"
+              ]
+            },
+            "rank": "Queen",
+            "court_role": "Water of Earth"
+          },
+          {
+            "name": "King of Coins",
+            "keywords": [
+              "stability",
+              "dependability",
+              "confidence",
+              "intervention",
+              "authority",
+              "mastery",
+              "vision"
+            ],
+            "fortune_telling": [
+              "This card represents an older man with a financially, socially, and politically conservative spirit, likely born between August 12th and September 11th, who is known for putting his money where his mouth is"
+            ],
+            "meanings": {
+              "upright": [
+                "Becoming debt-free",
+                "Having more than enough to get by",
+                "Making contributions to a savings plan",
+                "Taking a new job with an eye toward advancing your career",
+                "Buying life or health insurance",
+                "Being confident in the bedroom",
+                "Taking on the role of enforcer when called upon to do so"
+              ],
+              "reversed": [
+                "Becoming so conservative you resist all change on principle alone",
+                "Ignoring innovations in the name of preserving tradition",
+                "Being smug or cocky",
+                "Becoming ruthlessly dedicated to profit or pleasure",
+                "Being sexually selfish",
+                "Bossing others around, especially when you're not empowered to do so"
+              ]
+            },
+            "rank": "King",
+            "court_role": "Fire of Earth"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/entities/oracle/predictive_divination_extension/plugins/qabalah.plugin.json
+++ b/entities/oracle/predictive_divination_extension/plugins/qabalah.plugin.json
@@ -1,0 +1,34 @@
+{
+  "qabalah": {
+    "schema_version": "1.0",
+    "version": "1.0",
+    "name": "Qabalah / Sefirot",
+    "assets": [
+      {
+        "ref": "sefirot",
+        "section": "sefirot",
+        "description": "Tree of Life sephiroth and path correspondences."
+      }
+    ],
+    "operations": {
+      "draw": {
+        "method": "path_lot",
+        "default_count": 3,
+        "layout_modes": [
+          "pillar",
+          "lightning_flash"
+        ],
+        "supports_positions": true
+      },
+      "interpret": {
+        "pipeline": [
+          "map_to_sephirot",
+          "overlay_tarot_paths",
+          "compose_reading_frame"
+        ],
+        "normalization": "reading_frame.v1"
+      }
+    },
+    "notes": "Qabalah draws rely on sefirot.sefirot.tree and sefirot.sefirot.paths data sets."
+  }
+}

--- a/entities/oracle/predictive_divination_extension/plugins/runes.plugin.json
+++ b/entities/oracle/predictive_divination_extension/plugins/runes.plugin.json
@@ -1,0 +1,35 @@
+{
+  "runes": {
+    "schema_version": "1.0",
+    "version": "1.0",
+    "name": "Runes (Elder Futhark)",
+    "assets": [
+      {
+        "ref": "runes_futhark",
+        "section": "elder_futhark",
+        "description": "24-rune Elder Futhark set with upright and merkstave interpretations."
+      }
+    ],
+    "operations": {
+      "draw": {
+        "method": "bag",
+        "supports_reversal": true,
+        "default_count": 3,
+        "layout_modes": [
+          "linear",
+          "cross",
+          "norns"
+        ]
+      },
+      "interpret": {
+        "pipeline": [
+          "lookup_rune",
+          "evaluate_positional_meaning",
+          "compose_reading_frame"
+        ],
+        "normalization": "reading_frame.v1"
+      }
+    },
+    "notes": "Runic draws require runes_futhark.elder_futhark.runes entries to include keywords and meanings."
+  }
+}

--- a/entities/oracle/predictive_divination_extension/plugins/tarot.plugin.json
+++ b/entities/oracle/predictive_divination_extension/plugins/tarot.plugin.json
@@ -1,0 +1,41 @@
+{
+  "tarot": {
+    "schema_version": "1.0",
+    "version": "1.0",
+    "name": "Tarot (Rider–Waite–Smith + overlays)",
+    "assets": [
+      {
+        "ref": "tarot_rws",
+        "section": "rws_1909",
+        "description": "Canonical 1909 Rider–Waite–Smith card library with majors, minors, keywords, and correspondences."
+      },
+      {
+        "ref": "tarot_expansions",
+        "section": "expansions",
+        "description": "Alternate numbering, Thoth overlays, elemental dignities, and spread templates."
+      }
+    ],
+    "operations": {
+      "draw": {
+        "method": "fisher_yates",
+        "supports_reversal": true,
+        "default_spread": "three_card",
+        "spread_overrides": {
+          "celtic_cross": 10,
+          "horseshoe": 7,
+          "relationship_bridge": 6
+        }
+      },
+      "interpret": {
+        "pipeline": [
+          "lookup_card_metadata",
+          "apply_elemental_dignity_modifiers",
+          "blend_expansion_overlays",
+          "compose_reading_frame"
+        ],
+        "normalization": "reading_frame.v1"
+      }
+    },
+    "notes": "Plugin expects tarot_rws.rws_1909 and tarot_expansions.expansions sections to be present locally."
+  }
+}

--- a/entities/oracle/predictive_divination_extension/plugins/western_astrology.plugin.json
+++ b/entities/oracle/predictive_divination_extension/plugins/western_astrology.plugin.json
@@ -1,0 +1,42 @@
+{
+  "western_astrology": {
+    "schema_version": "1.0",
+    "version": "1.0",
+    "name": "Astrology — Western Tropical",
+    "assets": [
+      {
+        "ref": "astro_tables",
+        "section": "western",
+        "description": "Sign, planet, house, aspect, and dignity tables for tropical western astrology."
+      }
+    ],
+    "operations": {
+      "draw": {
+        "method": "ephemeris_lookup",
+        "requires_payload": [
+          "datetime",
+          "lat",
+          "lon"
+        ],
+        "optional_payload": [
+          "house_system"
+        ],
+        "outputs": [
+          "planet_positions",
+          "house_cusps",
+          "aspect_grid"
+        ]
+      },
+      "interpret": {
+        "pipeline": [
+          "derive_sign_and_house_context",
+          "score_aspects",
+          "synthesize_themes",
+          "compose_reading_frame"
+        ],
+        "normalization": "reading_frame.v1"
+      }
+    },
+    "notes": "Astro resolver expects astro_tables.western metadata to be present for fallback when ephemeris precision is limited."
+  }
+}


### PR DESCRIPTION
## Summary
- add the tarot, rune, astrology, and sefirot asset libraries under the predictive divination extension
- create plugin manifests for tarot, runes, western astrology, and qabalah that reference the restored asset sections
- validate plugin asset references to ensure the extension resolves local data without external fetches

## Testing
- python - <<'PY'
import json, pathlib

root = pathlib.Path('entities/oracle/predictive_divination_extension')
with (root / 'predictive_divination_extension.json').open() as fh:
    extension = json.load(fh)['predictive_divination_extension']

registry = extension['asset_registry']

# Load assets
assets = {}
for key, info in registry.items():
    path = pathlib.Path(info['source']['path'])
    with path.open() as fh:
        assets[key] = json.load(fh)

# Validate plugins
plugin_dir = root / 'plugins'
for plugin_file in plugin_dir.glob('*.plugin.json'):
    with plugin_file.open() as fh:
        plugin_data = json.load(fh)
    plugin_key, plugin = next(iter(plugin_data.items()))
    for asset in plugin['assets']:
        ref = asset['ref']
        section = asset['section']
        if ref not in assets:
            raise SystemExit(f"Plugin {plugin_key} references missing asset ref {ref}")
        if section not in assets[ref]:
            raise SystemExit(f"Plugin {plugin_key} section {section} not found in asset {ref}")
print('All plugin asset references validated.')
PY
- for file in entities/oracle/predictive_divination_extension/assets/*.json entities/oracle/predictive_divination_extension/plugins/*.json; do
  python -m json.tool "$file" > /dev/null || exit 1
done

------
https://chatgpt.com/codex/tasks/task_e_68d0aa8e054c83209c71703089e47068