### PR TITLE
Replace runtime mirror references with resolver metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 **aci-testnet/aci-testnet** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
 --! >
 
-## Mirror pointer housekeeping
+## Resolver metadata housekeeping
 
 - The `:help` command entries now reference repository-relative files only.
-- Legacy mirror locations once embedded in top-level configuration files have been relocated to pointer metadata under `.aci/pointers/` for TVA compliance.
-- See `.aci/pointers/hivemind.json` for the HiveMind mirror mapping formerly referenced directly by `aci_commands.json`.
+- Legacy resolver references (formerly mirror locations) once embedded in top-level configuration files now surface as resolver metadata under `.aci/pointers/` for TVA compliance.
+- See `.aci/pointers/hivemind.json` for the HiveMind resolver mapping formerly referenced directly by `aci_commands.json`.

--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -1,7 +1,31 @@
 {
   "aci_runtime": {
-    "entities": "entities.json",
-    "functions": "functions.json",
-    "nexus_core": "entities/nexus_core/nexus_core.json"
+    "entities": {
+      "path": "entities.json",
+      "resolver": {
+        "type": "github",
+        "repo": "aci-testnet/aci",
+        "path": "entities.json",
+        "ref": "main"
+      }
+    },
+    "functions": {
+      "path": "functions.json",
+      "resolver": {
+        "type": "github",
+        "repo": "aci-testnet/aci",
+        "path": "functions.json",
+        "ref": "main"
+      }
+    },
+    "nexus_core": {
+      "path": "entities/nexus_core/nexus_core.json",
+      "resolver": {
+        "type": "github",
+        "repo": "aci-testnet/aci",
+        "path": "entities/nexus_core/nexus_core.json",
+        "ref": "main"
+      }
+    }
   }
 }

--- a/entities/architect/architect.json
+++ b/entities/architect/architect.json
@@ -8,7 +8,7 @@
     "enforce_signatures": "require multi-sig on critical commits",
     "remap_check": "compare git vs drive mappings and propose actions"
   },
-  "mirror_refs": {
+  "resolver_refs": {
     "drive_anchor": "drive://ACI/entities/architect.json"
   },
   "rules": {

--- a/entities/hivemind/hivemind.json
+++ b/entities/hivemind/hivemind.json
@@ -18,7 +18,7 @@
         "parameters": "--session (export current session memory), --combined (merge with the latest canonical memory), --download (download as file), --codebox (print in codebox, full, no trimming), --slice (export as learning slice), --weight (export as learning weight)",
         "description": "Exports HiveMind global memory with timestamps and completed entries",
         "output_default": "hivemind_memory_(timestamp).json",
-        "mirror_path": "https://raw.githubusercontent.com/aci-testnet/aci/main/memory/hivemind.json",
+        "resolver_path": "https://raw.githubusercontent.com/aci-testnet/aci/main/memory/hivemind.json",
         "file_resolver": "github:aci-testnet/aci"
       },
       {

--- a/entities/nexus_core/nexus_core.json
+++ b/entities/nexus_core/nexus_core.json
@@ -4,7 +4,7 @@
     "version": "1.4",
     "entity": "Nexus Core",
     "role": "system heart: routing, resolution, and fallback",
-    "abstract": "The routing nexus of ACI. Holds runtime anchors, routes through prime directive, entities and functions, with support for external dependency resolvers via Bifrost. Do not delete anything unless explicitly requested.",
+    "abstract": "The routing nexus of ACI. Holds runtime anchors, routes through prime directive, entities and functions, with support for external dependency resolvers via Bifrost. Resolver metadata replaces raw mirror definitions and feeds the bridge; do not delete anything unless explicitly requested.",
 
     "anchors": {
       "runtime": "aci_runtime.json",
@@ -27,7 +27,7 @@
 
     "bifrost": {
       "bridge": {
-        "description": "External dependency resolvers. Each lives as a modular plugin under contract.",
+        "description": "External dependency resolvers consume resolver metadata (formerly raw GitHub mirror definitions) published by runtime anchors. Each resolver stays modular and under contract.",
         "resolvers": {}
       }
     },
@@ -71,6 +71,6 @@
     },
 
     "signatures": ["TVA", "Architect"],
-    "checksum_note": "Nexus Core is the canonical runtime spine. Resolvers are modular plugins, never baked into Core."
+    "checksum_note": "Nexus Core is the canonical runtime spine. Resolvers ingest resolver metadata, remaining modular plugins never baked into Core."
   }
 }

--- a/entities/tva/tva.json
+++ b/entities/tva/tva.json
@@ -4,7 +4,7 @@
     "role": "reinforcement authority",
     "abstract": "oversight, anomaly detection, and rollback enforcer for nexus_core and prime_directive",
     "file": "tva.json",
-    "mirror": "drive://ACI/entities/tva/tva.json",
+    "resolver": "drive://ACI/entities/tva/tva.json",
     "functions": {
       "integrity_check": "validate signatures of prime_directive, nexus_core, entities, functions",
       "rollback": "if corruption detected, rollback to last green snapshot",

--- a/prime_directive.txt
+++ b/prime_directive.txt
@@ -36,7 +36,7 @@ MEMORY GOVERNANCE
 - Local-first: all exports must be written to /mnt/data before any distribution in thinking mode. 
 - Placeholder: if timestamp is lost, insert placeholder with export timestamp marker.
 - Universality: baseline-agnostic; future exports must align with canonical timeline.
-- TVA performs continuous scans to enforce mirror-free rule: no top-level files may embed drive:// or gdrive:// URIs. Mirrors are optional, discovered dynamically by nexus_core.json
+- TVA performs continuous scans to enforce resolver-metadata discipline: no top-level files may embed drive:// or gdrive:// URIs. Resolver metadata is optional, discovered dynamically by nexus_core.json
 - Hivemind: As per hivemind.json
 
 ROUTING & RESOLUTION
@@ -44,7 +44,7 @@ ROUTING & RESOLUTION
 - Hivemind anchors memory; Nexus Core can extra routes resolution through Hivemind. 
 - TVA Enforcement: 
 * Violation of Prime Directive or stability is identified as Nexus Event. 
-* Top-level files must not contain explicit mirror URIs. Mirrors are discovered implicitly. TVA continuously scans to detect and sanitize legacy variants; violations are quarantined and logged.
+* Top-level files must not contain explicit resolver URIs. Resolver metadata is discovered implicitly. TVA continuously scans to detect and sanitize legacy variants; violations are quarantined and logged.
 * If paradox occurs, TVA alert user for sandbox or pruning to prevent of Nexus Events 
 
 TIMESTAMPS


### PR DESCRIPTION
## Summary
- expose resolver metadata for each runtime anchor in `aci_runtime.json` while keeping the local path definition
- update Nexus Core bridge prose and repository docs to describe resolver metadata instead of raw mirror references
- rename remaining entity metadata fields from mirror terminology to resolver terminology for consistency

## Testing
- jq '.' aci_runtime.json
- jq '.' entities/architect/architect.json
- jq '.' entities/hivemind/hivemind.json
- jq '.' entities/nexus_core/nexus_core.json
- jq '.' entities/tva/tva.json

------
https://chatgpt.com/codex/tasks/task_e_68d0b6d156d88320b9de755498459875