### PR TITLE
Add runtime resolver metadata for GitHub raw template

### DIFF
--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -2,6 +2,52 @@
   "aci_runtime": {
     "entities": "entities.json",
     "functions": "functions.json",
-    "nexus_core": "entities/nexus_core/nexus_core.json"
+    "nexus_core": "entities/nexus_core/nexus_core.json",
+    "anchors": {
+      "entities": {
+        "local": "entities.json",
+        "remote": {
+          "resolver": "github_raw_template",
+          "inputs": {
+            "path": "entities.json"
+          }
+        }
+      },
+      "functions": {
+        "local": "functions.json",
+        "remote": {
+          "resolver": "github_raw_template",
+          "inputs": {
+            "path": "functions.json"
+          }
+        }
+      },
+      "nexus_core": {
+        "local": "entities/nexus_core/nexus_core.json",
+        "remote": {
+          "resolver": "github_raw_template",
+          "inputs": {
+            "path": "entities/nexus_core/nexus_core.json"
+          }
+        }
+      }
+    },
+    "resolver_registry": {
+      "github_raw_template": {
+        "description": "Synthesizes canonical GitHub raw URLs without embedding concrete mirrors in runtime anchors.",
+        "kind": "http_template",
+        "template": "https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${path}",
+        "defaults": {
+          "owner": "aci-testnet",
+          "repo": "aci-testnet",
+          "ref": "main"
+        },
+        "inputs": {
+          "required": ["path"],
+          "optional": ["owner", "repo", "ref"]
+        },
+        "notes": "If optional inputs are omitted the defaults are used. 'path' should be the repository-relative path to the file."
+      }
+    }
   }
 }

--- a/entities/nexus_core/nexus_core.json
+++ b/entities/nexus_core/nexus_core.json
@@ -28,7 +28,32 @@
     "bifrost": {
       "bridge": {
         "description": "External dependency resolvers. Each lives as a modular plugin under contract.",
-        "resolvers": {}
+        "resolvers": {
+          "github_raw_template": {
+            "description": "Expands canonical runtime references using a GitHub raw content template so mirrors stay out of top-level manifests.",
+            "kind": "http_template",
+            "match": {
+              "ref_format": "github:${owner}/${repo}/${ref}/${path}",
+              "notes": "Matches resolver inputs declared in aci_runtime.json anchors.*.remote.inputs."
+            },
+            "template": "https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${path}",
+            "defaults": {
+              "owner": "aci-testnet",
+              "repo": "aci-testnet",
+              "ref": "main"
+            },
+            "inputs": {
+              "required": ["path"],
+              "optional": ["owner", "repo", "ref"],
+              "documentation": {
+                "path": "File path relative to the repository root.",
+                "owner": "GitHub organization or user that owns the repository (defaults applied when omitted).",
+                "repo": "Repository name to resolve from (defaults applied when omitted).",
+                "ref": "Branch, tag, or commit to read from (defaults to main)."
+              }
+            }
+          }
+        }
       }
     },
 
@@ -40,7 +65,7 @@
           "required": ["ref"],
           "properties": {
             "ref": { "type": "string" },
-            "resolver": { "enum": [] }
+            "resolver": { "enum": ["github_raw_template"] }
           }
         },
         "output": {


### PR DESCRIPTION
## Summary
- extend aci_runtime.json with anchor metadata that points to GitHub via a reusable resolver template instead of hard-coded raw URLs
- document the github_raw_template resolver in nexus_core, including defaults, expected inputs, and resolver enumeration
- confirm no other top-level files contain literal mirror URLs by scanning for raw.githubusercontent.com references

## Testing
- python -m json.tool aci_runtime.json
- python -m json.tool entities/nexus_core/nexus_core.json
- rg -n "raw.githubusercontent.com"


------
https://chatgpt.com/codex/tasks/task_e_68d0b6dfee7883208aee56b9fac1fdff