### PR TITLE
Update HiveMind log to use Hivemind Legacy Context terminology

### DIFF
--- a/memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json
+++ b/memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json
@@ -86,7 +86,7 @@
         },
         {
           "role": "user",
-          "content": "Collapse Total Recall into HiveMind; exports must be newest_first, with timestamps per entry and completion (no deletion). (context preserved)",
+          "content": "Collapse Hivemind Legacy Context into HiveMind; exports must be newest_first, with timestamps per entry and completion (no deletion). (context preserved)",
           "timestamp": "2025-09-19T10:59:37Z",
           "ts_sort": "2025-09-19T10:59:37Z",
           "export_ts_hint": "2025-09-19T11:00:41Z",


### PR DESCRIPTION
## Summary
- replace the remaining "Total Recall" reference in the HiveMind export log with "Hivemind Legacy Context"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d395f41c4083208adb55b47bca2d8c