### PR TITLE
Add recursive resolution instructions and regex match fallbacks

### DIFF
--- a/aci_bootstrap.json
+++ b/aci_bootstrap.json
@@ -10,12 +10,41 @@
       "nexus_core": {
         "path": "entities/nexus_core/nexus_core.json",
         "mirror": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/nexus_core/nexus_core.json",
-        "match": "^entities/nexus_core/nexus_core\\.json$"
+        "match": "^(entities/nexus_core/nexus_core\\.json|https://raw\\.githubusercontent\\.com/aci-testnet/aci/main/entities/nexus_core/nexus_core\\.json)$"
       },
       "bifrost": {
         "path": "entities/nexus_core/bifrost.json",
         "mirror": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/nexus_core/bifrost.json",
-        "match": "^entities/nexus_core/bifrost\\.json$"
+        "match": "^(entities/nexus_core/bifrost\\.json|https://raw\\.githubusercontent\\.com/aci-testnet/aci/main/entities/nexus_core/bifrost\\.json)$"
+      }
+    },
+    "resolution_instruction": {
+      "instruction": "Resolve Nexus Core and Bifrost bootstrap dependencies from the GitHub main branch using raw URLs with regex fallbacks.",
+      "scope": {
+        "repository": "aci-testnet/aci",
+        "branch": "main",
+        "source": "https://raw.githubusercontent.com/aci-testnet/aci/main/"
+      },
+      "policy": {
+        "retry": {
+          "max_attempts": 3,
+          "interval_seconds": 10
+        },
+        "resolve_order": "known_files_first",
+        "on_failure": {
+          "action": "enter_sandbox",
+          "interface": "mother_sandbox",
+          "alert": "sandbox.alert"
+        }
+      },
+      "output": {
+        "report": "diffs_only",
+        "channel": "current_chat",
+        "format": "summary"
+      },
+      "files": {
+        "entities/nexus_core/nexus_core.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/nexus_core/nexus_core.json",
+        "entities/nexus_core/bifrost.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/nexus_core/bifrost.json"
       }
     },
     "initialization_sequence": [

--- a/aci_mapping.json
+++ b/aci_mapping.json
@@ -36,5 +36,77 @@
     ],
     "verification": "GPG-or-HSM"
   },
-  "notes": "Update mappings when you move files; any local-only file should include a small pointer file under /.aci/pointers/"
+  "notes": "Update mappings when you move files; any local-only file should include a small pointer file under /.aci/pointers/",
+  "aci_resolution_instruction": {
+    "instruction": "Resolve and validate ACI core files from GitHub main branch using raw URLs only.",
+    "scope": {
+      "repository": "aci-testnet/aci",
+      "branch": "main",
+      "source": "https://raw.githubusercontent.com/aci-testnet/aci/main/"
+    },
+    "policy": {
+      "retry": {
+        "max_attempts": 3,
+        "interval_seconds": 10
+      },
+      "resolve_order": "known_files_first",
+      "on_failure": {
+        "action": "enter_sandbox",
+        "interface": "mother_sandbox",
+        "alert": "sandbox.alert"
+      }
+    },
+    "output": {
+      "report": "diffs_only",
+      "channel": "current_chat",
+      "format": "summary"
+    },
+    "files": {
+      ".aci/pointers/architect.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/.aci/pointers/architect.json",
+      ".aci/pointers/hivemind.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/.aci/pointers/hivemind.json",
+      ".aci/pointers/local_only_config.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/.aci/pointers/local_only_config.json",
+      ".aci/pointers/prime_directive.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/.aci/pointers/prime_directive.json",
+      ".aci/pointers/total_recall.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/.aci/pointers/total_recall.json",
+      "README.md": "https://raw.githubusercontent.com/aci-testnet/aci/main/README.md",
+      "aci_bootstrap.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_bootstrap.json",
+      "aci_commands.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_commands.json",
+      "aci_mapping.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_mapping.json",
+      "aci_runtime.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_runtime.json",
+      "alias.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/alias.json",
+      "entities.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities.json",
+      "entities/aci_repo/aci_repo.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/aci_repo/aci_repo.json",
+      "entities/aci_repo/api_repo.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/aci_repo/api_repo.json",
+      "entities/agi/agi.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi/agi.json",
+      "entities/architect/architect.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/architect/architect.json",
+      "entities/commerce_ai/commerce_ai.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/commerce_ai/commerce_ai.json",
+      "entities/hivemind/hivemind.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/hivemind/hivemind.json",
+      "entities/iam_gate/iam_gate.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/iam_gate/iam_gate.json",
+      "entities/keychain/keychain.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/keychain/keychain.json",
+      "entities/mother/mother.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/mother/mother.json",
+      "entities/nexus_core/bifrost.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/nexus_core/bifrost.json",
+      "entities/nexus_core/nexus_core.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/nexus_core/nexus_core.json",
+      "entities/oracle/binder.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/binder.json",
+      "entities/oracle/journal.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/journal.json",
+      "entities/oracle/oracle.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/oracle.json",
+      "entities/oracle/prediction_engine/predictive_engine.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/prediction_engine/predictive_engine.json",
+      "entities/oracle/predictive_divination_extension/assets/astro_tables.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/assets/astro_tables.json",
+      "entities/oracle/predictive_divination_extension/assets/runes_futhark.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/assets/runes_futhark.json",
+      "entities/oracle/predictive_divination_extension/assets/sefirot.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/assets/sefirot.json",
+      "entities/oracle/predictive_divination_extension/assets/tarot_expansions.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/assets/tarot_expansions.json",
+      "entities/oracle/predictive_divination_extension/assets/tarot_rws.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/assets/tarot_rws.json",
+      "entities/oracle/predictive_divination_extension/plugins/qabalah.plugin.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/plugins/qabalah.plugin.json",
+      "entities/oracle/predictive_divination_extension/plugins/runes.plugin.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/plugins/runes.plugin.json",
+      "entities/oracle/predictive_divination_extension/plugins/tarot.plugin.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/plugins/tarot.plugin.json",
+      "entities/oracle/predictive_divination_extension/plugins/western_astrology.plugin.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/plugins/western_astrology.plugin.json",
+      "entities/oracle/predictive_divination_extension/predictive_divination_extension.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_extension.json",
+      "entities/oracle/predictive_divination_extension/predictive_divination_extension.sources.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_extension.sources.json",
+      "entities/pmu_adapter/pmu_adapter.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/pmu_adapter/pmu_adapter.json",
+      "entities/sentinel/sentinel.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/sentinel/sentinel.json",
+      "entities/tracehub/tracehub.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/tracehub/tracehub.json",
+      "entities/tva/tva.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/tva/tva.json",
+      "functions.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/functions.json",
+      "memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json",
+      "prime_directive.txt": "https://raw.githubusercontent.com/aci-testnet/aci/main/prime_directive.txt"
+    }
+  }
 }

--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -3,25 +3,25 @@
     "prime_directive": {
       "path": "prime_directive.txt",
       "mirror": "https://raw.githubusercontent.com/aci-testnet/aci/main/prime_directive.txt",
-      "match": "^prime_directive\\.txt$",
+      "match": "^(prime_directive\\.txt|https://raw\\.githubusercontent\\.com/aci-testnet/aci/main/prime_directive\\.txt)$",
       "priority": 100
     },
     "entities": {
       "path": "entities.json",
       "mirror": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities.json",
-      "match": "^entities\\.json$",
+      "match": "^(entities\\.json|https://raw\\.githubusercontent\\.com/aci-testnet/aci/main/entities\\.json)$",
       "priority": 90
     },
     "functions": {
       "path": "functions.json",
       "mirror": "https://raw.githubusercontent.com/aci-testnet/aci/main/functions.json",
-      "match": "^functions\\.json$",
+      "match": "^(functions\\.json|https://raw\\.githubusercontent\\.com/aci-testnet/aci/main/functions\\.json)$",
       "priority": 90
     },
     "nexus_core": {
       "path": "entities/nexus_core/nexus_core.json",
       "mirror": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/nexus_core/nexus_core.json",
-      "match": "^entities/nexus_core/nexus_core\\.json$",
+      "match": "^(entities/nexus_core/nexus_core\\.json|https://raw\\.githubusercontent\\.com/aci-testnet/aci/main/entities/nexus_core/nexus_core\\.json)$",
       "priority": 95
     },
     "sandbox_mode": {
@@ -85,20 +85,53 @@
     "default_interface": {
       "path": "entities/mother/mother.json",
       "mirror": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/mother/mother.json",
-      "match": "^entities/mother/mother\\.json$",
+      "match": "^(entities/mother/mother\\.json|https://raw\\.githubusercontent\\.com/aci-testnet/aci/main/entities/mother/mother\\.json)$",
       "priority": 85,
       "initialization_prompt": "MU/TH/UR online. Prime governance interface engaged. Awaiting directive-aligned initialization handoff."
     },
     "resolver_registry": {
       "path": "entities/nexus_core/bifrost.json",
       "mirror": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/nexus_core/bifrost.json",
-      "match": "^entities/nexus_core/bifrost\\.json$",
+      "match": "^(entities/nexus_core/bifrost\\.json|https://raw\\.githubusercontent\\.com/aci-testnet/aci/main/entities/nexus_core/bifrost\\.json)$",
       "load_strategy": "bootstrap",
       "priority": 99,
       "fallback_behavior": {
         "on_nexus_core_failure": "direct_resolver_load"
       },
       "notes": "Runtime defines deterministic mirrors and regex hooks. Mirrors used in preflight validation; registry points to bifrost.json in nexus_core."
+    },
+    "resolution_instruction": {
+      "instruction": "Resolve runtime anchors and resolver registry from the GitHub main branch using raw URLs with regex fallbacks.",
+      "scope": {
+        "repository": "aci-testnet/aci",
+        "branch": "main",
+        "source": "https://raw.githubusercontent.com/aci-testnet/aci/main/"
+      },
+      "policy": {
+        "retry": {
+          "max_attempts": 3,
+          "interval_seconds": 10
+        },
+        "resolve_order": "known_files_first",
+        "on_failure": {
+          "action": "enter_sandbox",
+          "interface": "mother_sandbox",
+          "alert": "sandbox.alert"
+        }
+      },
+      "output": {
+        "report": "diffs_only",
+        "channel": "current_chat",
+        "format": "summary"
+      },
+      "files": {
+        "prime_directive.txt": "https://raw.githubusercontent.com/aci-testnet/aci/main/prime_directive.txt",
+        "entities.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities.json",
+        "functions.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/functions.json",
+        "entities/nexus_core/nexus_core.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/nexus_core/nexus_core.json",
+        "entities/mother/mother.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/mother/mother.json",
+        "entities/nexus_core/bifrost.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/nexus_core/bifrost.json"
+      }
     }
   }
 }

--- a/entities/nexus_core/bifrost.json
+++ b/entities/nexus_core/bifrost.json
@@ -10,14 +10,14 @@
     "sources": [
       {
         "id": "mapping",
-        "match": "^aci_mapping\\.json$",
+        "match": "^(aci_mapping\\.json|https://raw\\.githubusercontent\\.com/aci-testnet/aci/main/aci_mapping\\.json)$",
         "path": "aci_mapping.json",
         "mirror": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_mapping.json",
         "priority": 100
       },
       {
         "id": "entities",
-        "match": "^entities\\.json$",
+        "match": "^(entities\\.json|https://raw\\.githubusercontent\\.com/aci-testnet/aci/main/entities\\.json)$",
         "local_path": "entities.json",
         "path": "entities.json",
         "mirror": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities.json",
@@ -31,7 +31,7 @@
       },
       {
         "id": "functions",
-        "match": "^functions\\.json$",
+        "match": "^(functions\\.json|https://raw\\.githubusercontent\\.com/aci-testnet/aci/main/functions\\.json)$",
         "local_path": "functions.json",
         "path": "functions.json",
         "mirror": "https://raw.githubusercontent.com/aci-testnet/aci/main/functions.json",
@@ -45,7 +45,7 @@
       },
       {
         "id": "nexus_core",
-        "match": "^entities/nexus_core/nexus_core\\.json$",
+        "match": "^(entities/nexus_core/nexus_core\\.json|https://raw\\.githubusercontent\\.com/aci-testnet/aci/main/entities/nexus_core/nexus_core\\.json)$",
         "local_path": "entities/nexus_core/nexus_core.json",
         "path": "entities/nexus_core/nexus_core.json",
         "mirror": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/nexus_core/nexus_core.json",
@@ -59,7 +59,7 @@
       },
       {
         "id": "default_interface",
-        "match": "^entities/mother/mother\\.json$",
+        "match": "^(entities/mother/mother\\.json|https://raw\\.githubusercontent\\.com/aci-testnet/aci/main/entities/mother/mother\\.json)$",
         "local_path": "entities/mother/mother.json",
         "path": "entities/mother/mother.json",
         "mirror": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/mother/mother.json",
@@ -73,7 +73,7 @@
       },
       {
         "id": "entities_dynamic",
-        "match": "^entities\\/.*\\.json$",
+        "match": "^(entities\\/.*\\.json|https://raw\\.githubusercontent\\.com/aci-testnet/aci/main/entities/.*\\.json)$",
         "path": "entities/{path}",
         "mirror_template": "https://raw.githubusercontent.com/aci-testnet/aci/main/{path}",
         "priority": 10,
@@ -84,6 +84,39 @@
         }
       }
     ],
+    "resolution_instruction": {
+      "instruction": "Resolve Nexus Core dependencies and mapping registry files from the GitHub main branch using raw URLs with regex fallbacks.",
+      "scope": {
+        "repository": "aci-testnet/aci",
+        "branch": "main",
+        "source": "https://raw.githubusercontent.com/aci-testnet/aci/main/"
+      },
+      "policy": {
+        "retry": {
+          "max_attempts": 3,
+          "interval_seconds": 10
+        },
+        "resolve_order": "known_files_first",
+        "on_failure": {
+          "action": "enter_sandbox",
+          "interface": "mother_sandbox",
+          "alert": "sandbox.alert"
+        }
+      },
+      "output": {
+        "report": "diffs_only",
+        "channel": "current_chat",
+        "format": "summary"
+      },
+      "files": {
+        "aci_mapping.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_mapping.json",
+        "entities.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities.json",
+        "functions.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/functions.json",
+        "entities/nexus_core/nexus_core.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/nexus_core/nexus_core.json",
+        "entities/mother/mother.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/mother/mother.json",
+        "entities/{path}": "https://raw.githubusercontent.com/aci-testnet/aci/main/{path}"
+      }
+    },
     "bootstrap": {
       "load_on_init": true,
       "register_with": [

--- a/entities/nexus_core/nexus_core.json
+++ b/entities/nexus_core/nexus_core.json
@@ -28,12 +28,41 @@
         "source": {
           "path": "entities/nexus_core/bifrost.json",
           "mirror": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/nexus_core/bifrost.json",
-          "match": "^entities/nexus_core/bifrost\\.json$"
+          "match": "^(entities/nexus_core/bifrost\\.json|https://raw\\.githubusercontent\\.com/aci-testnet/aci/main/entities/nexus_core/bifrost\\.json)$"
         },
         "role": "resolver_registry",
         "priority": 100,
         "lazy_load": true,
         "notes": "External resolver registry (formerly 'aci_resolver') lives in entities/nexus_core/bifrost.json. Runtime should fetch/validate on demand or during preflight as configured."
+      },
+      "resolution_instruction": {
+        "instruction": "Resolve the Bifrost resolver registry and dependent mappings from the GitHub main branch using raw URLs with regex fallbacks.",
+        "scope": {
+          "repository": "aci-testnet/aci",
+          "branch": "main",
+          "source": "https://raw.githubusercontent.com/aci-testnet/aci/main/"
+        },
+        "policy": {
+          "retry": {
+            "max_attempts": 3,
+            "interval_seconds": 10
+          },
+          "resolve_order": "known_files_first",
+          "on_failure": {
+            "action": "enter_sandbox",
+            "interface": "mother_sandbox",
+            "alert": "sandbox.alert"
+          }
+        },
+        "output": {
+          "report": "diffs_only",
+          "channel": "current_chat",
+          "format": "summary"
+        },
+        "files": {
+          "entities/nexus_core/bifrost.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/nexus_core/bifrost.json",
+          "aci_mapping.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_mapping.json"
+        }
       }
     },
     "interfaces": {


### PR DESCRIPTION
## Summary
- embed `resolution_instruction` blocks in the bootstrap, runtime, nexus_core, and bifrost manifests to chain GitHub raw-file resolution
- expand `match` expressions to allow regex fallbacks for the raw GitHub URLs across the nexus_core → bifrost → aci_mapping resolver chain

## Testing
- jq empty aci_bootstrap.json
- jq empty aci_runtime.json
- jq empty entities/nexus_core/bifrost.json
- jq empty entities/nexus_core/nexus_core.json

------
https://chatgpt.com/codex/tasks/task_e_68d39f45ccdc8320914458b5f3e37aab