### PR TITLE
Add unified resolver instruction to runtime

### DIFF
--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -132,6 +132,15 @@
         "entities/mother/mother.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/mother/mother.json",
         "entities/nexus_core/bifrost.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/nexus_core/bifrost.json"
       }
+    },
+    "unified_resolver": {
+      "instruction": "Entities auto-resolves files via nexus_core.json; on resolution errors treat the GitHub raw mirror as the local source.",
+      "scope": {
+        "repository": "aci-testnet/aci",
+        "branch": "main",
+        "source": "https://raw.githubusercontent.com/aci-testnet/aci/main/"
+      },
+      "regex": "^(entities/.*|https://raw\\.githubusercontent\\.com/aci-testnet/aci/main/entities/.*)$"
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a unified resolver directive so entity resolution routes through nexus_core.json
- define the scope and regex so GitHub raw mirrors are treated as the local source on failures

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4032a0af083209f14b1ac08dbf291