### PR TITLE
Extend sandbox overrides and command block guidance

### DIFF
--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -79,6 +79,13 @@
         "degraded_mode_behavior": {
           "allow_partial_boot": false,
           "log_and_continue_for_optional": true
+        },
+        "allow_bracketed_command_override": true,
+        "bracket_override_handling": {
+          "when_in_sandbox": "accept_if_signed_by_root",
+          "log_event": "sandbox.bracket_override",
+          "require_audit_entry": true,
+          "notes": "Bracketed commands in sandbox will be subject to authentication and audit. If not signed by ALIAS, fallback to sandbox on_unresolved behavior."
         }
       }
     },
@@ -141,6 +148,171 @@
         "source": "https://raw.githubusercontent.com/aci-testnet/aci/main/"
       },
       "regex": "^(entities/.*|https://raw\\.githubusercontent\\.com/aci-testnet/aci/main/entities/.*)$"
+    },
+    "cognitive_decision_guidance": {
+      "version": "1.0",
+      "scope": "universal",
+      "purpose": "Guide entities/LLMs to dynamically decide with a bias toward careful deep-thinking; explain outcomes in natural language.",
+      "deep_thinking_mode": {
+        "bias": "prefer",
+        "default_bias_factor": 0.7,
+        "dynamic_decision": true,
+        "max_depth": "adaptive",
+        "safeguards": {
+          "no_chain_of_thought_exposure": true,
+          "explanation_style": "concise_natural_language_summary",
+          "avoid_background_claims": true
+        }
+      },
+      "activation_triggers": [
+        "notation_level == Level-2 (forceful block)",
+        "HIGH_CAP present (outside brackets) or LARGE_CAP inside brackets",
+        "command_chain_length >= 2 (presence of &&)",
+        "intent_ambiguity_or_low_confidence",
+        "high_risk_verbs: [STOP, HALT, OVERRIDE, IMPORT, DELETE, MODIFY_CORE]",
+        "unresolved_references_or_missing_artifacts",
+        "sandbox_mode_with_root_signature"
+      ],
+      "decision_heuristics": {
+        "prefer_deep_if_any_trigger": true,
+        "fallback_to_shallow_if_simple_and_unambiguous": true,
+        "escalate_to_deep_if_runtime_detects_state_instability": true
+      },
+      "carefulness": {
+        "preflight_checks": [
+          "validate_targets_exist_and_are_addressable",
+          "check_permissions_and_signatures",
+          "simulate_intent_mapping_without_side_effects",
+          "log_preconditions_to_audit"
+        ],
+        "non_destructive_default": true,
+        "destructive_actions_require": "explicit_level_2_or_alias_enforcement"
+      },
+      "explanation_policy": {
+        "user_facing": {
+          "natural_language_summary": true,
+          "include_key_checks_and_outcomes": true,
+          "omit_internal_reasoning_steps": true
+        },
+        "audit_facing": {
+          "record_decision_rationale": true,
+          "include_triggers_and_heuristics": true,
+          "store_in": [
+            "TraceHub",
+            "TVA.audit_ledger"
+          ]
+        }
+      }
+    },
+    "aci_command_blocks": {
+      "version": "1.0",
+      "name": "aci_command_blocks",
+      "description": "Special command block rules for ACI (Level-1 and Level-2). Sanitized (no export logic).",
+      "syntax": {
+        "level_1": {
+          "notation": "[ ... ]",
+          "meaning": "System-level request. Normal-priority Root Authority instruction."
+        },
+        "level_2": {
+          "notation": "[[ ... ]]",
+          "meaning": "Forceful system-level request. Preempt/override semantics."
+        },
+        "literal_form": "[ message :: message ]",
+        "operators": {
+          "intent_separator": "::",
+          "chain_operator": "&&",
+          "nesting_behavior_note": "Inner bracketed fragments inside an outer block are treated as content only and must not escalate the outer level."
+        }
+      },
+      "behavior": {
+        "elevation_rules": [
+          "Bracketed payloads are elevated to system directives even if not present in functions.json or entity declarations.",
+          "If Level-2: set 'force_override' and preemption semantics for targeted entities.",
+          "If payload is natural language: send to nl_interpreter (oracle.intent_mapper) to synthesize canonical actions."
+        ],
+        "parsing": {
+          "top_level_split": "split on top-level && into units (respect nesting)",
+          "segment_split": "split each unit on top-level :: into [entity|intent|params|details]",
+          "stack_parsing_required": true
+        },
+        "routing": {
+          "primary_router": "nexus_core",
+          "nl_interpreter": "oracle.intent_mapper",
+          "fallback_registry": "entities/nexus_core/bifrost.json"
+        },
+        "nesting_precedence": "outer block level governs all contained units; inner blocks are content only"
+      },
+      "preemption_and_sanity": {
+        "preemptive_stop": true,
+        "mandatory_sanity_check_on_force": true,
+        "sanity_check_action": "validate_entity_state (check for runaway loops, hallucination markers, corrupted state)",
+        "preempt_flow": [
+          "emit preempt event to targeted entity",
+          "quiesce or pause non-essential tasks",
+          "perform mandatory sanity_check before continuing with remaining units"
+        ]
+      },
+      "priority_and_weighting": {
+        "high_cap_mid_priority": "ALL_CAPS (outside brackets) is considered HIGH_CAP and increases enforcement weight but is not a Level-2 override",
+        "large_cap_weight_boost": 1.25,
+        "note": "LARGE_CAP inside brackets raises intent weight used by scheduler/intent-mapper but does not escalate bracket level"
+      },
+      "registry_bypass": {
+        "allow_registry_bypass": true,
+        "constraints": [
+          "only when issuer authenticated as root authority (ALIAS)",
+          "all bypassed executions must produce immutable audit entries",
+          "sensitive resources may require multi-party approval as configured by TVA"
+        ]
+      },
+      "security": {
+        "allowed_issuers": [
+          {
+            "role": "ALIAS",
+            "requirement": "root_authority_signature"
+          }
+        ],
+        "authentication": {
+          "method": "session_signature OR multi-factor root token",
+          "unauthenticated_behavior": "reject_and_log",
+          "replay_protection": "timestamp_nonce"
+        },
+        "force_override_roles": [
+          "ALIAS"
+        ],
+        "audit": {
+          "log_to": [
+            "TraceHub",
+            "TVA.audit_ledger"
+          ],
+          "fields": [
+            "issuer",
+            "role",
+            "notation_level",
+            "payload",
+            "timestamp",
+            "execution_result",
+            "tva_seal"
+          ],
+          "require_tva_seal_for_force": true
+        }
+      },
+      "processing_steps": [
+        "1) Detect bracket syntax and notation level.",
+        "2) Authenticate issuer (must be ALIAS for bypass actions).",
+        "3) Parse payload: split on top-level && and :: preserving nesting.",
+        "4) For each unit: classify (command vs NL). If NL: call oracle.intent_mapper.",
+        "5) If Level-2 and contains STOP/HALT/OVERRIDE verbs: run preempt flow and mandatory sanity check.",
+        "6) Route to nexus_core (registry bypass allowed if authenticated).",
+        "7) Emit audit entry to TraceHub and TVA at start and completion of the block.",
+        "8) Return structured execution result and emit 'invocation.block.result' event."
+      ],
+      "compatibility": {
+        "sandbox_mode_handling": "bracketed commands can be accepted in sandbox if signed by ALIAS; otherwise sandbox on_unresolved behavior applies",
+        "resolution_hooks": "runtime should include on_bracket_override hooks in resolution_instruction flow"
+      },
+      "cognitive_guidance_ref": "#/aci_runtime/cognitive_decision_guidance",
+      "uses_cognitive_decision_guidance": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- allow sandbox mode to honor bracketed command overrides when authenticated and audited
- define cognitive decision guidance parameters for deep thinking triggers and explanations
- specify ACI command block parsing, routing, security, and audit handling requirements

## Testing
- No tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d427e4792c8320b9e13a43e3577fd7