### PR TITLE
Add cognitive decision guidance flags to Nexus policy

### DIFF
--- a/entities/nexus_core/nexus_core.json
+++ b/entities/nexus_core/nexus_core.json
@@ -15,7 +15,9 @@
       "local_first": true,
       "fallback_allowed": true,
       "no_embedded_ids_in_entities": true,
-      "explain_on_error": true
+      "explain_on_error": true,
+      "uses_cognitive_decision_guidance": true,
+      "cognitive_guidance_ref": "aci_runtime.json#/aci_runtime/cognitive_decision_guidance"
     },
     "routing": {
       "default_strategy": "deterministic_first_available",


### PR DESCRIPTION
## Summary
- enable cognitive decision guidance in the Nexus Core policy
- link to the runtime cognitive guidance definition for policy reference

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d42959d21883208830d702fe90aca8