### PR TITLE
Add resolver reference to top-level JSON manifests

### DIFF
--- a/aci_bootstrap.json
+++ b/aci_bootstrap.json
@@ -35,5 +35,12 @@
       "notes": "If promotion criteria not met, do not continue to full bootstrap; start sandbox and emit alert."
     },
     "notes": "Manifest enforces preflight promotion check. If promotion fails, runtime enters sandbox and waits (with retries) before final decision."
+  },
+  "aci_files_resolution_solution": {
+    "key": "aci_github_resolver",
+    "file": "aci_github_resolver.json",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json"
   }
 }

--- a/aci_commands.json
+++ b/aci_commands.json
@@ -13,5 +13,12 @@
         "hivemind": "entities/hivemind/hivemind.json"
       }
     }
+  },
+  "aci_files_resolution_solution": {
+    "key": "aci_github_resolver",
+    "file": "aci_github_resolver.json",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json"
   }
 }

--- a/aci_github_resolver.json
+++ b/aci_github_resolver.json
@@ -106,5 +106,12 @@
       "memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json",
       "prime_directive.txt": "https://raw.githubusercontent.com/aci-testnet/aci/main/prime_directive.txt"
     }
+  },
+  "aci_files_resolution_solution": {
+    "key": "aci_github_resolver",
+    "file": "aci_github_resolver.json",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json"
   }
 }

--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -248,7 +248,14 @@
         "resolution_hooks": "runtime should include on_bracket_override hooks in resolution_instruction flow"
       },
       "cognitive_guidance_ref": "#/aci_runtime/cognitive_decision_guidance",
-      "uses_cognitive_decision_guidance": true
+    "uses_cognitive_decision_guidance": true
     }
+  },
+  "aci_files_resolution_solution": {
+    "key": "aci_github_resolver",
+    "file": "aci_github_resolver.json",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json"
   }
 }

--- a/alias.json
+++ b/alias.json
@@ -43,5 +43,12 @@
       "tva": "enforces anomaly control and runtime authority",
       "mother": "serves as governance interface"
     }
+  },
+  "aci_files_resolution_solution": {
+    "key": "aci_github_resolver",
+    "file": "aci_github_resolver.json",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json"
   }
 }

--- a/entities.json
+++ b/entities.json
@@ -217,5 +217,12 @@
         "file": "pmu_adapter.json"
       }
     ]
+  },
+  "aci_files_resolution_solution": {
+    "key": "aci_github_resolver",
+    "file": "aci_github_resolver.json",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json"
   }
 }

--- a/functions.json
+++ b/functions.json
@@ -730,5 +730,12 @@
         "pipeline": "aci.repo.help"
       }
     ]
+  },
+  "aci_files_resolution_solution": {
+    "key": "aci_github_resolver",
+    "file": "aci_github_resolver.json",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json"
   }
 }


### PR DESCRIPTION
## Summary
- add a shared `aci_files_resolution_solution` block to each root JSON manifest
- reference the GitHub resolver metadata so files can be traced back to their canonical source

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4cf190b9083209371070deadfa69c