### PR TITLE
Rename resolver metadata and remove append-only policies

### DIFF
--- a/aci_bootstrap.json
+++ b/aci_bootstrap.json
@@ -35,5 +35,13 @@
       "notes": "If promotion criteria not met, do not continue to full bootstrap; start sandbox and emit alert."
     },
     "notes": "Manifest enforces preflight promotion check. If promotion fails, runtime enters sandbox and waits (with retries) before final decision."
+  },
+  "mirror_resolution_policy": {
+    "key": "aci_github_resolver",
+    "file": "aci_github_resolver.json",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
+    "context": "Canonical raw URLs take precedence over local copies during resolution."
   }
 }

--- a/aci_commands.json
+++ b/aci_commands.json
@@ -13,5 +13,13 @@
         "hivemind": "entities/hivemind/hivemind.json"
       }
     }
+  },
+  "mirror_resolution_policy": {
+    "key": "aci_github_resolver",
+    "file": "aci_github_resolver.json",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
+    "context": "Canonical raw URLs take precedence over local copies during resolution."
   }
 }

--- a/aci_github_resolver.json
+++ b/aci_github_resolver.json
@@ -106,5 +106,13 @@
       "memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json",
       "prime_directive.txt": "https://raw.githubusercontent.com/aci-testnet/aci/main/prime_directive.txt"
     }
+  },
+  "mirror_resolution_policy": {
+    "key": "aci_github_resolver",
+    "file": "aci_github_resolver.json",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
+    "context": "Canonical raw URLs take precedence over local copies during resolution."
   }
 }

--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -248,7 +248,15 @@
         "resolution_hooks": "runtime should include on_bracket_override hooks in resolution_instruction flow"
       },
       "cognitive_guidance_ref": "#/aci_runtime/cognitive_decision_guidance",
-      "uses_cognitive_decision_guidance": true
+    "uses_cognitive_decision_guidance": true
     }
+  },
+  "mirror_resolution_policy": {
+    "key": "aci_github_resolver",
+    "file": "aci_github_resolver.json",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
+    "context": "Canonical raw URLs take precedence over local copies during resolution."
   }
 }

--- a/alias.json
+++ b/alias.json
@@ -43,5 +43,13 @@
       "tva": "enforces anomaly control and runtime authority",
       "mother": "serves as governance interface"
     }
+  },
+  "mirror_resolution_policy": {
+    "key": "aci_github_resolver",
+    "file": "aci_github_resolver.json",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
+    "context": "Canonical raw URLs take precedence over local copies during resolution."
   }
 }

--- a/entities.json
+++ b/entities.json
@@ -217,5 +217,13 @@
         "file": "pmu_adapter.json"
       }
     ]
+  },
+  "mirror_resolution_policy": {
+    "key": "aci_github_resolver",
+    "file": "aci_github_resolver.json",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
+    "context": "Canonical raw URLs take precedence over local copies during resolution."
   }
 }

--- a/entities/agi/README_ENTITY.txt
+++ b/entities/agi/README_ENTITY.txt
@@ -40,7 +40,7 @@ RESPONSE:
 - On success: copy artifact to persist://, append entry to aci/memory/agi_memory/agi_memory_YYYYMMDD.json, emit TVA post-anchor + finalize Sentinel audit.
 
 7) MEMORY POLICY
-- Namespace = AGI; append-only index; long-term writes to Hivemind with namespace lock.
+- Namespace = AGI; governed index; long-term writes to Hivemind with namespace lock.
 - Prune rule: summaries_only_after_90d (raw logs persist in TraceHub).
 
 8) EXECUTION ENVIRONMENT (AGI PROXY)

--- a/entities/hivemind/hivemind.json
+++ b/entities/hivemind/hivemind.json
@@ -61,7 +61,7 @@
     "rules": {
       "schema_normalization": "map legacy fields → canonical schema",
       "preserve_unknown": "keep unmatched fields under hivemind_legacy_context",
-      "append_only": "override by autocompletion",
+      "mutation_policy": "autocompletion may revise legacy records",
       "no_deletion": "true"
     },
     "workflow": [

--- a/entities/nexus_core/nexus_core.json
+++ b/entities/nexus_core/nexus_core.json
@@ -47,5 +47,13 @@
       "Architect"
     ],
     "checksum_note": "Nexus Core is the canonical runtime spine. Lookup integrations remain modular and separate from Core."
+  },
+  "mirror_resolution_policy": {
+    "key": "aci_github_resolver",
+    "file": "aci_github_resolver.json",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
+    "context": "Canonical raw URLs take precedence over local copies during resolution."
   }
 }

--- a/entities/oracle/binder.json
+++ b/entities/oracle/binder.json
@@ -11,7 +11,7 @@
     },
     "rules": {
       "library_files_are_static": true,
-      "memory_entries_are_append_only": false,
+      "memory_entries_allow_rewrite": true,
       "updates_require_root_signature": [
         "ALIAS",
         "Sentinel",

--- a/entities/tva/tva.json
+++ b/entities/tva/tva.json
@@ -23,7 +23,7 @@
     },
     "integrity": {
       "anchoring": "fileverse",
-      "append_only": true
+      "update_policy": "anchored_revisions_allowed"
     },
     "audit": {
       "created_at": "2025-09-19T12:14:06Z"

--- a/functions.json
+++ b/functions.json
@@ -730,5 +730,13 @@
         "pipeline": "aci.repo.help"
       }
     ]
+  },
+  "mirror_resolution_policy": {
+    "key": "aci_github_resolver",
+    "file": "aci_github_resolver.json",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
+    "context": "Canonical raw URLs take precedence over local copies during resolution."
   }
 }

--- a/memory/agi_memory/agi_memory_20250924.json
+++ b/memory/agi_memory/agi_memory_20250924.json
@@ -12,7 +12,7 @@
         "promote": ["ALIAS", "TVA", "Sentinel"]
       }
     },
-    "retention": { "policy": "append_only", "prune": "summaries_only_after_90d" },
+    "retention": { "policy": "governed_updates", "prune": "summaries_only_after_90d" },
     "logs": [],
     "summaries": [],
     "links": {


### PR DESCRIPTION
## Summary
- rename the shared resolver metadata block to `mirror_resolution_policy` across core manifests and include context that canonical raw URLs outrank local files
- align the GitHub resolver manifest with the new policy naming and priority context
- drop legacy append-only rules in memory-related documentation and manifests in favor of governed update wording

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4cf190b9083209371070deadfa69c