### PR TITLE
Rename resolver metadata and remove append-only policies

### DIFF
--- a/aci_bootstrap.json
+++ b/aci_bootstrap.json
@@ -35,5 +35,13 @@
       "notes": "If promotion criteria not met, do not continue to full bootstrap; start sandbox and emit alert."
     },
     "notes": "Manifest enforces preflight promotion check. If promotion fails, runtime enters sandbox and waits (with retries) before final decision."
+  },
+  "mirror_resolution_policy": {
+    "key": "aci_github_resolver",
+    "file": "aci_github_resolver.json",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
+    "context": "Canonical raw URLs take precedence over local copies during resolution."
   }
 }

--- a/aci_bootstrap.json
+++ b/aci_bootstrap.json
@@ -37,11 +37,13 @@
     "notes": "Manifest enforces preflight promotion check. If promotion fails, runtime enters sandbox and waits (with retries) before final decision."
   },
   "mirror_resolution_policy": {
-    "key": "aci_github_resolver",
-    "file": "aci_github_resolver.json",
-    "canonical_source": "github",
-    "repo": "aci-testnet/aci",
-    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
-    "context": "Canonical raw URLs take precedence over local copies during resolution."
+    "context": "Canonical raw URLs take precedence over local copies during resolution.",
+    "aci_files_resolution_solution": {
+      "key": "aci_github_resolver",
+      "file": "aci_github_resolver.json",
+      "canonical_source": "github",
+      "repo": "aci-testnet/aci",
+      "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json"
+    }
   }
 }

--- a/aci_commands.json
+++ b/aci_commands.json
@@ -13,5 +13,13 @@
         "hivemind": "entities/hivemind/hivemind.json"
       }
     }
+  },
+  "mirror_resolution_policy": {
+    "key": "aci_github_resolver",
+    "file": "aci_github_resolver.json",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
+    "context": "Canonical raw URLs take precedence over local copies during resolution."
   }
 }

--- a/aci_commands.json
+++ b/aci_commands.json
@@ -15,11 +15,13 @@
     }
   },
   "mirror_resolution_policy": {
-    "key": "aci_github_resolver",
-    "file": "aci_github_resolver.json",
-    "canonical_source": "github",
-    "repo": "aci-testnet/aci",
-    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
-    "context": "Canonical raw URLs take precedence over local copies during resolution."
+    "context": "Canonical raw URLs take precedence over local copies during resolution.",
+    "aci_files_resolution_solution": {
+      "key": "aci_github_resolver",
+      "file": "aci_github_resolver.json",
+      "canonical_source": "github",
+      "repo": "aci-testnet/aci",
+      "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json"
+    }
   }
 }

--- a/aci_github_resolver.json
+++ b/aci_github_resolver.json
@@ -1,118 +1,128 @@
 {
   "aci_github_resolver": {
-  "version": "1.20250921.00",
-  "canonical_source": "github",
-  "repo": "aci-testnet/aci", 
-  "rules": {
-    "git_is_canonical_for": [
-      "/prime_directive.txt",
-      "/aci_runtime.json",
-      "/aci_bootstrap.json",
-      "/entities/**",
-      "/memory/**"
-    ],
-    "sync_policy": 
-    "pull_on_webhook": true
-    "chatgpt_connector": true
-  },
-  "signatures": {
-    "required": [
-      "ALIAS",
-      "TVA" 
-      "Sentinel"
-    ],
-  },
-  "notes": "Update mappings when you move files.", 
-  "aci_resolution_instruction": {
-    "instruction": "Resolve and validate ACI files from GitHub main branch using raw URLs only.",
-    "scope": {
-      "repository": "aci-testnet/aci",
-      "branch": "main",
-      "source": "https://raw.githubusercontent.com/aci-testnet/aci/main/"
-    },
-    "policy": {
-      "retry": {
-        "max_attempts": 3,
-        "interval_seconds": 10
-      },
-      "resolve_order": "known_files_first",
-      "on_failure": {
-        "action": "enter_sandbox",
-        "interface": "mother_sandbox",
-        "alert": "sandbox.alert"
+    "version": "1.20250921.00",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "rules": {
+      "git_is_canonical_for": [
+        "/prime_directive.txt",
+        "/aci_runtime.json",
+        "/aci_bootstrap.json",
+        "/entities/**",
+        "/memory/**"
+      ],
+      "sync_policy": {
+        "pull_on_webhook": true,
+        "chatgpt_connector": true
       }
     },
-    "output": {
-      "report": "diffs_only",
-      "channel": "current_chat",
-      "format": "summary"
+    "signatures": {
+      "required": [
+        "ALIAS",
+        "TVA",
+        "Sentinel"
+      ]
     },
-    "files": {
-      "README.md": "https://raw.githubusercontent.com/aci-testnet/aci/main/README.md",
-      "aci/memory/agi_memory/.gitkeep": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci/memory/agi_memory/.gitkeep",
-      "aci/memory/agi_memory/alice_agi_memory_placeholder.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci/memory/agi_memory/alice_agi_memory_placeholder.json",
-      "aci/memory/hivemind_memory/logs/.gitkeep": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci/memory/hivemind_memory/logs/.gitkeep",
-      "aci_bootstrap.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_bootstrap.json",
-      "aci_commands.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_commands.json",
-      "aci_mapping.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_mapping.json",
-      "aci_runtime.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_runtime.json",
-      "alias.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/alias.json",
-      "entities.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities.json",
-      "entities/aci_repo/aci_repo.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/aci_repo/aci_repo.json",
-      "entities/aci_repo/api_repo.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/aci_repo/api_repo.json",
-      "entities/agi/README_ENTITY.txt": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi/README_ENTITY.txt",
-      "entities/agi/agi.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi/agi.json",
-      "entities/agi_proxy/agi_proxy.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/agi_proxy.json",
-      "entities/agi_proxy/eec/eec_agent_langchain_rag.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_agent_langchain_rag.json",
-      "entities/agi_proxy/eec/eec_base.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_base.json",
-      "entities/agi_proxy/eec/eec_eval_agieval.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_eval_agieval.json",
-      "entities/agi_proxy/eec/eec_eval_arc_agi2.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_eval_arc_agi2.json",
-      "entities/agi_proxy/eec/eec_export_hivemind_full.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_export_hivemind_full.json",
-      "entities/agi_proxy/eec/eec_export_hivemind_session.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_export_hivemind_session.json",
-      "entities/agi_proxy/eec/eec_faiss_build.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_faiss_build.json",
-      "entities/agi_proxy/eec/eec_peft_train_lora.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_peft_train_lora.json",
-      "entities/agi_proxy/eec/eec_sft_deepspeed.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_sft_deepspeed.json",
-      "entities/agi_proxy/eec/eec_transformers_infer.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_transformers_infer.json",
-      "entities/agi_proxy/eec/eec_trl_ppo.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_trl_ppo.json",
-      "entities/architect/architect.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/architect/architect.json",
-      "entities/commerce_ai/commerce_ai.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/commerce_ai/commerce_ai.json",
-      "entities/hivemind/hivemind.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/hivemind/hivemind.json",
-      "entities/iam_gate/iam_gate.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/iam_gate/iam_gate.json",
-      "entities/keychain/keychain.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/keychain/keychain.json",
-      "entities/mother/mother.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/mother/mother.json",
-      "entities/nexus_core/bifrost.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/nexus_core/bifrost.json",
-      "entities/nexus_core/nexus_core.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/nexus_core/nexus_core.json",
-      "entities/oracle/binder.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/binder.json",
-      "entities/oracle/journal.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/journal.json",
-      "entities/oracle/oracle.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/oracle.json",
-      "entities/oracle/prediction_engine/predictive_engine.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/prediction_engine/predictive_engine.json",
-      "entities/oracle/predictive_divination_extension/assets/astro_tables.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/assets/astro_tables.json",
-      "entities/oracle/predictive_divination_extension/assets/runes_futhark.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/assets/runes_futhark.json",
-      "entities/oracle/predictive_divination_extension/assets/sefirot.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/assets/sefirot.json",
-      "entities/oracle/predictive_divination_extension/assets/tarot_expansions.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/assets/tarot_expansions.json",
-      "entities/oracle/predictive_divination_extension/assets/tarot_rws.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/assets/tarot_rws.json",
-      "entities/oracle/predictive_divination_extension/plugins/qabalah.plugin.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/plugins/qabalah.plugin.json",
-      "entities/oracle/predictive_divination_extension/plugins/runes.plugin.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/plugins/runes.plugin.json",
-      "entities/oracle/predictive_divination_extension/plugins/tarot.plugin.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/plugins/tarot.plugin.json",
-      "entities/oracle/predictive_divination_extension/plugins/western_astrology.plugin.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/plugins/western_astrology.plugin.json",
-      "entities/oracle/predictive_divination_extension/predictive_divination_extension.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_extension.json",
-      "entities/oracle/predictive_divination_extension/predictive_divination_extension.sources.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_extension.sources.json",
-      "entities/pmu_adapter/pmu_adapter.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/pmu_adapter/pmu_adapter.json",
-      "entities/sentinel/sentinel.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/sentinel/sentinel.json",
-      "entities/tracehub/tracehub.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/tracehub/tracehub.json",
-      "entities/tva/tva.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/tva/tva.json",
-      "functions.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/functions.json",
-      "memory/agi_memory/agi_memory_20250924.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/memory/agi_memory/agi_memory_20250924.json",
-      "memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json",
-      "prime_directive.txt": "https://raw.githubusercontent.com/aci-testnet/aci/main/prime_directive.txt"
+    "notes": "Update mappings when you move files.",
+    "aci_resolution_instruction": {
+      "instruction": "Resolve and validate ACI files from GitHub main branch using raw URLs only.",
+      "scope": {
+        "repository": "aci-testnet/aci",
+        "branch": "main",
+        "source": "https://raw.githubusercontent.com/aci-testnet/aci/main/"
+      },
+      "policy": {
+        "retry": {
+          "max_attempts": 3,
+          "interval_seconds": 10
+        },
+        "resolve_order": "known_files_first",
+        "on_failure": {
+          "action": "enter_sandbox",
+          "interface": "mother_sandbox",
+          "alert": "sandbox.alert"
+        }
+      },
+      "output": {
+        "report": "diffs_only",
+        "channel": "current_chat",
+        "format": "summary"
+      },
+      "regex_search": [
+        {
+          "pattern": "^(aci_.*\\.json|alias\\.json|entities/.+\\.json|memory/.+\\.json|prime_directive\\.txt)$",
+          "description": "Fallback resolution using regular expressions when file mappings are unknown."
+        }
+      ],
+      "link_index": {
+        "README.md": "https://raw.githubusercontent.com/aci-testnet/aci/main/README.md",
+        "aci/memory/agi_memory/.gitkeep": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci/memory/agi_memory/.gitkeep",
+        "aci/memory/agi_memory/alice_agi_memory_placeholder.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci/memory/agi_memory/alice_agi_memory_placeholder.json",
+        "aci/memory/hivemind_memory/logs/.gitkeep": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci/memory/hivemind_memory/logs/.gitkeep",
+        "aci_bootstrap.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_bootstrap.json",
+        "aci_commands.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_commands.json",
+        "aci_mapping.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_mapping.json",
+        "aci_runtime.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_runtime.json",
+        "alias.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/alias.json",
+        "entities.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities.json",
+        "entities/aci_repo/aci_repo.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/aci_repo/aci_repo.json",
+        "entities/aci_repo/api_repo.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/aci_repo/api_repo.json",
+        "entities/agi/README_ENTITY.txt": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi/README_ENTITY.txt",
+        "entities/agi/agi.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi/agi.json",
+        "entities/agi_proxy/agi_proxy.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/agi_proxy.json",
+        "entities/agi_proxy/eec/eec_agent_langchain_rag.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_agent_langchain_rag.json",
+        "entities/agi_proxy/eec/eec_base.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_base.json",
+        "entities/agi_proxy/eec/eec_eval_agieval.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_eval_agieval.json",
+        "entities/agi_proxy/eec/eec_eval_arc_agi2.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_eval_arc_agi2.json",
+        "entities/agi_proxy/eec/eec_export_hivemind_full.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_export_hivemind_full.json",
+        "entities/agi_proxy/eec/eec_export_hivemind_session.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_export_hivemind_session.json",
+        "entities/agi_proxy/eec/eec_faiss_build.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_faiss_build.json",
+        "entities/agi_proxy/eec/eec_peft_train_lora.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_peft_train_lora.json",
+        "entities/agi_proxy/eec/eec_sft_deepspeed.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_sft_deepspeed.json",
+        "entities/agi_proxy/eec/eec_transformers_infer.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_transformers_infer.json",
+        "entities/agi_proxy/eec/eec_trl_ppo.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_trl_ppo.json",
+        "entities/architect/architect.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/architect/architect.json",
+        "entities/commerce_ai/commerce_ai.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/commerce_ai/commerce_ai.json",
+        "entities/hivemind/hivemind.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/hivemind/hivemind.json",
+        "entities/iam_gate/iam_gate.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/iam_gate/iam_gate.json",
+        "entities/keychain/keychain.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/keychain/keychain.json",
+        "entities/mother/mother.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/mother/mother.json",
+        "entities/nexus_core/bifrost.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/nexus_core/bifrost.json",
+        "entities/nexus_core/nexus_core.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/nexus_core/nexus_core.json",
+        "entities/oracle/binder.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/binder.json",
+        "entities/oracle/journal.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/journal.json",
+        "entities/oracle/oracle.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/oracle.json",
+        "entities/oracle/prediction_engine/predictive_engine.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/prediction_engine/predictive_engine.json",
+        "entities/oracle/predictive_divination_extension/predictive_divination_library/astro_tables.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/astro_tables.json",
+        "entities/oracle/predictive_divination_extension/predictive_divination_library/runes_futhark.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/runes_futhark.json",
+        "entities/oracle/predictive_divination_extension/predictive_divination_library/sefirot.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/sefirot.json",
+        "entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_expansions.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_expansions.json",
+        "entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_rws.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_rws.json",
+        "entities/oracle/predictive_divination_extension/plugins/qabalah.plugin.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/plugins/qabalah.plugin.json",
+        "entities/oracle/predictive_divination_extension/plugins/runes.plugin.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/plugins/runes.plugin.json",
+        "entities/oracle/predictive_divination_extension/plugins/tarot.plugin.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/plugins/tarot.plugin.json",
+        "entities/oracle/predictive_divination_extension/plugins/western_astrology.plugin.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/plugins/western_astrology.plugin.json",
+        "entities/oracle/predictive_divination_extension/predictive_divination_extension.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_extension.json",
+        "entities/oracle/predictive_divination_extension/predictive_divination_library/predictive_divination_library.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/predictive_divination_library.json",
+        "entities/pmu_adapter/pmu_adapter.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/pmu_adapter/pmu_adapter.json",
+        "entities/sentinel/sentinel.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/sentinel/sentinel.json",
+        "entities/tracehub/tracehub.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/tracehub/tracehub.json",
+        "entities/tva/tva.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/tva/tva.json",
+        "functions.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/functions.json",
+        "memory/agi_memory/agi_memory_20250924.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/memory/agi_memory/agi_memory_20250924.json",
+        "memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json",
+        "prime_directive.txt": "https://raw.githubusercontent.com/aci-testnet/aci/main/prime_directive.txt"
+      }
     }
   },
   "mirror_resolution_policy": {
-    "key": "aci_github_resolver",
-    "file": "aci_github_resolver.json",
-    "canonical_source": "github",
-    "repo": "aci-testnet/aci",
-    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
-    "context": "Canonical raw URLs take precedence over local copies during resolution."
+    "context": "Canonical raw URLs take precedence over local copies during resolution.",
+    "aci_files_resolution_solution": {
+      "key": "aci_github_resolver",
+      "file": "aci_github_resolver.json",
+      "canonical_source": "github",
+      "repo": "aci-testnet/aci",
+      "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json"
+    }
   }
 }

--- a/aci_github_resolver.json
+++ b/aci_github_resolver.json
@@ -106,5 +106,13 @@
       "memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json",
       "prime_directive.txt": "https://raw.githubusercontent.com/aci-testnet/aci/main/prime_directive.txt"
     }
+  },
+  "mirror_resolution_policy": {
+    "key": "aci_github_resolver",
+    "file": "aci_github_resolver.json",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
+    "context": "Canonical raw URLs take precedence over local copies during resolution."
   }
 }

--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -252,11 +252,13 @@
     }
   },
   "mirror_resolution_policy": {
-    "key": "aci_github_resolver",
-    "file": "aci_github_resolver.json",
-    "canonical_source": "github",
-    "repo": "aci-testnet/aci",
-    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
-    "context": "Canonical raw URLs take precedence over local copies during resolution."
+    "context": "Canonical raw URLs take precedence over local copies during resolution.",
+    "aci_files_resolution_solution": {
+      "key": "aci_github_resolver",
+      "file": "aci_github_resolver.json",
+      "canonical_source": "github",
+      "repo": "aci-testnet/aci",
+      "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json"
+    }
   }
 }

--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -248,7 +248,15 @@
         "resolution_hooks": "runtime should include on_bracket_override hooks in resolution_instruction flow"
       },
       "cognitive_guidance_ref": "#/aci_runtime/cognitive_decision_guidance",
-      "uses_cognitive_decision_guidance": true
+    "uses_cognitive_decision_guidance": true
     }
+  },
+  "mirror_resolution_policy": {
+    "key": "aci_github_resolver",
+    "file": "aci_github_resolver.json",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
+    "context": "Canonical raw URLs take precedence over local copies during resolution."
   }
 }

--- a/alias.json
+++ b/alias.json
@@ -43,5 +43,13 @@
       "tva": "enforces anomaly control and runtime authority",
       "mother": "serves as governance interface"
     }
+  },
+  "mirror_resolution_policy": {
+    "key": "aci_github_resolver",
+    "file": "aci_github_resolver.json",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
+    "context": "Canonical raw URLs take precedence over local copies during resolution."
   }
 }

--- a/alias.json
+++ b/alias.json
@@ -45,11 +45,13 @@
     }
   },
   "mirror_resolution_policy": {
-    "key": "aci_github_resolver",
-    "file": "aci_github_resolver.json",
-    "canonical_source": "github",
-    "repo": "aci-testnet/aci",
-    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
-    "context": "Canonical raw URLs take precedence over local copies during resolution."
+    "context": "Canonical raw URLs take precedence over local copies during resolution.",
+    "aci_files_resolution_solution": {
+      "key": "aci_github_resolver",
+      "file": "aci_github_resolver.json",
+      "canonical_source": "github",
+      "repo": "aci-testnet/aci",
+      "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json"
+    }
   }
 }

--- a/entities.json
+++ b/entities.json
@@ -217,5 +217,13 @@
         "file": "pmu_adapter.json"
       }
     ]
+  },
+  "mirror_resolution_policy": {
+    "key": "aci_github_resolver",
+    "file": "aci_github_resolver.json",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
+    "context": "Canonical raw URLs take precedence over local copies during resolution."
   }
 }

--- a/entities.json
+++ b/entities.json
@@ -219,11 +219,13 @@
     ]
   },
   "mirror_resolution_policy": {
-    "key": "aci_github_resolver",
-    "file": "aci_github_resolver.json",
-    "canonical_source": "github",
-    "repo": "aci-testnet/aci",
-    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
-    "context": "Canonical raw URLs take precedence over local copies during resolution."
+    "context": "Canonical raw URLs take precedence over local copies during resolution.",
+    "aci_files_resolution_solution": {
+      "key": "aci_github_resolver",
+      "file": "aci_github_resolver.json",
+      "canonical_source": "github",
+      "repo": "aci-testnet/aci",
+      "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json"
+    }
   }
 }

--- a/entities/agi/README_ENTITY.txt
+++ b/entities/agi/README_ENTITY.txt
@@ -40,7 +40,7 @@ RESPONSE:
 - On success: copy artifact to persist://, append entry to aci/memory/agi_memory/agi_memory_YYYYMMDD.json, emit TVA post-anchor + finalize Sentinel audit.
 
 7) MEMORY POLICY
-- Namespace = AGI; append-only index; long-term writes to Hivemind with namespace lock.
+- Namespace = AGI; governed index; long-term writes to Hivemind with namespace lock.
 - Prune rule: summaries_only_after_90d (raw logs persist in TraceHub).
 
 8) EXECUTION ENVIRONMENT (AGI PROXY)

--- a/entities/hivemind/hivemind.json
+++ b/entities/hivemind/hivemind.json
@@ -61,7 +61,7 @@
     "rules": {
       "schema_normalization": "map legacy fields → canonical schema",
       "preserve_unknown": "keep unmatched fields under hivemind_legacy_context",
-      "append_only": "override by autocompletion",
+      "mutation_policy": "autocompletion may revise legacy records",
       "no_deletion": "true"
     },
     "workflow": [

--- a/entities/nexus_core/nexus_core.json
+++ b/entities/nexus_core/nexus_core.json
@@ -47,5 +47,13 @@
       "Architect"
     ],
     "checksum_note": "Nexus Core is the canonical runtime spine. Lookup integrations remain modular and separate from Core."
+  },
+  "mirror_resolution_policy": {
+    "key": "aci_github_resolver",
+    "file": "aci_github_resolver.json",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
+    "context": "Canonical raw URLs take precedence over local copies during resolution."
   }
 }

--- a/entities/oracle/binder.json
+++ b/entities/oracle/binder.json
@@ -11,7 +11,7 @@
     },
     "rules": {
       "library_files_are_static": true,
-      "memory_entries_are_append_only": false,
+      "memory_entries_allow_rewrite": true,
       "updates_require_root_signature": [
         "ALIAS",
         "Sentinel",

--- a/entities/tva/tva.json
+++ b/entities/tva/tva.json
@@ -23,7 +23,7 @@
     },
     "integrity": {
       "anchoring": "fileverse",
-      "append_only": true
+      "update_policy": "anchored_revisions_allowed"
     },
     "audit": {
       "created_at": "2025-09-19T12:14:06Z"

--- a/functions.json
+++ b/functions.json
@@ -730,5 +730,13 @@
         "pipeline": "aci.repo.help"
       }
     ]
+  },
+  "mirror_resolution_policy": {
+    "key": "aci_github_resolver",
+    "file": "aci_github_resolver.json",
+    "canonical_source": "github",
+    "repo": "aci-testnet/aci",
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
+    "context": "Canonical raw URLs take precedence over local copies during resolution."
   }
 }

--- a/functions.json
+++ b/functions.json
@@ -732,11 +732,13 @@
     ]
   },
   "mirror_resolution_policy": {
-    "key": "aci_github_resolver",
-    "file": "aci_github_resolver.json",
-    "canonical_source": "github",
-    "repo": "aci-testnet/aci",
-    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
-    "context": "Canonical raw URLs take precedence over local copies during resolution."
+    "context": "Canonical raw URLs take precedence over local copies during resolution.",
+    "aci_files_resolution_solution": {
+      "key": "aci_github_resolver",
+      "file": "aci_github_resolver.json",
+      "canonical_source": "github",
+      "repo": "aci-testnet/aci",
+      "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json"
+    }
   }
 }

--- a/memory/agi_memory/agi_memory_20250924.json
+++ b/memory/agi_memory/agi_memory_20250924.json
@@ -12,7 +12,7 @@
         "promote": ["ALIAS", "TVA", "Sentinel"]
       }
     },
-    "retention": { "policy": "append_only", "prune": "summaries_only_after_90d" },
+    "retention": { "policy": "governed_updates", "prune": "summaries_only_after_90d" },
     "logs": [],
     "summaries": [],
     "links": {


### PR DESCRIPTION
## Summary
- rename the shared resolver metadata block to `mirror_resolution_policy` across core manifests and include context that canonical raw URLs outrank local files
- align the GitHub resolver manifest with the new policy naming and priority context
- drop legacy append-only rules in memory-related documentation and manifests in favor of governed update wording

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4cf190b9083209371070deadfa69c