### PR TITLE
Refine entity_bias standalone function blueprint

### DIFF
--- a/library/cognitive_functions/entity_bias.json
+++ b/library/cognitive_functions/entity_bias.json
@@ -1,0 +1,173 @@
+{
+  "function": {
+    "name": "entity_bias",
+    "kind": "standalone_cognitive_function",
+    "schema_version": "0.1.0",
+    "version": "0.1-draft",
+    "status": "draft",
+    "summary": "Standalone semantic hinting service that captures weighted bias terms for each ACI entity and exposes scoring utilities for search, tagging, and predictive routing.",
+    "problem_statement": "ACI entities need a consistent, inspectable way to express their semantic territory so that downstream services can align rankings, tags, and predictive behaviors without hand-tuned overrides.",
+    "goals": [
+      "Represent every entity as a normalized semantic profile consumable by multiple runtimes.",
+      "Offer deterministic keyword-based scoring that can run without embedding dependencies while remaining extensible.",
+      "Integrate with ACI search, ingestion, memory, and Oracle adapters through explicit hooks rather than implicit side effects.",
+      "Surface confidence and conflict telemetry so TVA can adjudicate ownership disputes quickly."
+    ],
+    "ownership": {
+      "stewards": ["Architect", "Sentinel", "TVA", "Oracle"],
+      "registration": {
+        "list_in": "functions.json",
+        "registration_note": "List this file as an external reference; do not inline the blueprint payload."
+      }
+    },
+    "runtime_contract": {
+      "inputs": {
+        "text": {
+          "type": "string",
+          "description": "Arbitrary text snippet or query to align against entity semantic profiles."
+        },
+        "keywords": {
+          "type": "array[string]",
+          "description": "Optional explicit keyword list for rapid matching (used by ingestion flows)."
+        },
+        "options": {
+          "type": "object",
+          "description": "Execution knobs (similarity mode, top_k, normalization flags)."
+        }
+      },
+      "outputs": {
+        "ranked_entities": {
+          "type": "array[EntityScore]",
+          "description": "Ordered list of entities with confidence, matched terms, and trace metadata."
+        },
+        "diagnostics": {
+          "type": "object",
+          "description": "Per-call telemetry including applied boosts, normalization factors, and cache usage."
+        }
+      }
+    },
+    "data_model": {
+      "bias_profile": {
+        "description": "Normalized weighting dictionary keyed by entity name containing keyword-weight pairs and optional clusters.",
+        "fields": {
+          "entity": "Entity identifier (string).",
+          "keywords": "Dictionary of {token: weight} pairs normalized to sum to 1.0.",
+          "clusters": "Optional nested groups that capture related concepts with local weights.",
+          "metadata": "Attribution (author, timestamp, provenance, steward approvals)."
+        },
+        "storage": "Persist profiles in library/cognitive_functions/entity_bias_store.json or future service registry.",
+        "update_policy": "Weight edits require TVA approval; ingestion normalizes sums and logs deltas for audit."
+      }
+    },
+    "operations": {
+      "score_text": {
+        "signature": "score_text(text: str, *, top_k: int = 3, mode: Literal['cosine', 'jaccard'] = 'cosine') -> List[EntityScore]",
+        "workflow": [
+          "Tokenize, lowercase, and stem the text (reuse Architect preprocessing utils).",
+          "Compute similarity with each bias profile using selected mode and normalized weights.",
+          "Return ranked entities with confidence, matched tokens, and explanations."
+        ]
+      },
+      "match_keywords": {
+        "signature": "match_keywords(keywords: Iterable[str]) -> EntityScore",
+        "workflow": [
+          "Normalize keyword list (dedupe, stem, weight evenly unless overrides provided).",
+          "Compare against stored bias profiles via weighted overlap.",
+          "Return best entity with alternates if confidence < 0.6."
+        ]
+      },
+      "update_bias_profile": {
+        "signature": "update_bias_profile(entity: str, payload: BiasProfilePatch) -> BiasProfile",
+        "workflow": [
+          "Validate steward permissions via TVA before mutating weights.",
+          "Merge incoming weights, renormalize, and attach provenance metadata.",
+          "Trigger recalibration hooks for dependent services (search index, Oracle adapters)."
+        ]
+      }
+    },
+    "integration_points": {
+      "entity_match_pipeline": {
+        "id": "CF-EB-01",
+        "consumers": ["auto_tagging", "memory_alignment", "conflict_resolution"],
+        "steps": [
+          "Preprocess text or keyword payloads.",
+          "Score against all bias profiles and apply stewardship boosts.",
+          "Emit ranked entity list with rationale strings."
+        ]
+      },
+      "search_bias_adapter": {
+        "id": "CF-EB-02",
+        "trigger": "aci search",
+        "steps": [
+          "Detect explicit entity context flag or infer via entity_match_pipeline.",
+          "Expand query with top bias terms using decay factor α = 0.35 (cap boost at 1.8×).",
+          "Log applied boosts for explainability in search results."
+        ]
+      },
+      "auto_tagging": {
+        "id": "CF-EB-03",
+        "trigger": "New package/entity ingestion",
+        "steps": [
+          "Extract keywords from package metadata.",
+          "Invoke entity_match_pipeline for primary alignment.",
+          "Escalate to TVA if confidence spread < ε = 0.1."
+        ],
+        "outputs": ["primary_entity", "alternate_entities", "confidence_report"]
+      },
+      "memory_alignment": {
+        "id": "CF-EB-04",
+        "trigger": "Log export / hivemind sync",
+        "steps": [
+          "Chunk logs into semantic fragments.",
+          "Score each fragment and tag with top entity plus supporting terms.",
+          "Feed tagged fragments into summarizers for entity-specific digests."
+        ]
+      },
+      "predictive_integration": {
+        "id": "CF-EB-05",
+        "trigger": "Oracle symbolic prediction requests",
+        "steps": [
+          "Inject bias terms as auxiliary prompts for Oracle's symbolic planner.",
+          "Dampen low-signal terms via weight threshold β = 0.15.",
+          "Record influence metrics for model governance."
+        ]
+      }
+    },
+    "conflict_resolution": {
+      "overlap_threshold": 0.1,
+      "rules": [
+        "If multiple entities fall within overlap_threshold, pull TVA stewardship scores.",
+        "Favor entity with highest stewardship_score unless override flag is present.",
+        "Escalate to human review if adjusted scores remain within ±0.05."
+      ],
+      "audit": "Persist conflict cases in TVA ledger with inputs, weights, and adjudication notes."
+    },
+    "telemetry": {
+      "metrics": [
+        "entity_match_latency_ms",
+        "search_bias_boost_avg",
+        "auto_tag_accuracy",
+        "conflict_escalation_rate"
+      ],
+      "dashboards": [
+        "Weekly bias drift report",
+        "Entity steward activity log"
+      ],
+      "alerts": {
+        "bias_drift": "Trigger if cosine distance between successive bias profiles > 0.25.",
+        "low_confidence_match": "Notify TVA when >15% of auto tags fall below 0.5 confidence in a week."
+      }
+    },
+    "implementation_notes": [
+      "Prototype can reuse Architect cosine similarity utilities and TVA authorization helpers.",
+      "Cache normalized keyword vectors to reduce latency in high-traffic search flows.",
+      "Version bias profiles and expose diff endpoints for governance audits.",
+      "Future work: blend embedding-based similarity for long-form text fallback."
+    ],
+    "backlog": [
+      "Design steward-facing bias profile editor UI.",
+      "Integrate with Tracehub for end-to-end visibility on bias-influenced search sessions.",
+      "Explore reinforcement loop where Oracle predictions feed back into bias term weighting."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- reframe the entity_bias blueprint as a standalone cognitive function definition
- capture runtime contracts, ownership metadata, and integration hooks required for external registration
- streamline supporting operations, telemetry, and governance guidance for reuse across ACI services

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d556fb1f208320a4147beece05895b